### PR TITLE
Bump version to 0.1.93 and add user_id column migration for video edi…

### DIFF
--- a/client/src-tauri/Cargo.toml
+++ b/client/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clippster-ui"
-version = "0.1.92"
+version = "0.1.93"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/client/src-tauri/tauri.conf.json
+++ b/client/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Clippster",
-  "version": "0.1.92",
+  "version": "0.1.93",
   "identifier": "com.openworth.clippster",
   "build": {
     "beforeDevCommand": "yarn dev",
@@ -25,7 +25,7 @@
     ],
     "macOSPrivateApi": true,
     "security": {
-      "csp": "default-src 'self' asset: https://asset.localhost; connect-src 'self' asset: https://asset.localhost tauri: http://ipc.localhost http://localhost:* http://127.0.0.1:* https://clippster-server.fly.dev https: wss:; img-src 'self' asset: https://asset.localhost data: https:; media-src 'self' asset: https://asset.localhost tauri: blob: https: http://localhost:* http://127.0.0.1:*; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:",
+      "csp": "default-src 'self' asset: https://asset.localhost; connect-src 'self' asset: https://asset.localhost tauri: http://ipc.localhost http://localhost:* http://127.0.0.1:* https://clippster-server.fly.dev https: wss:; img-src 'self' asset: https://asset.localhost data: blob: https:; media-src 'self' asset: https://asset.localhost tauri: blob: https: http://localhost:* http://127.0.0.1:*; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:",
       "dangerousDisableAssetCspModification": [
         ".*/.*"
       ],

--- a/client/src/pages/OpenCutEditor.vue
+++ b/client/src/pages/OpenCutEditor.vue
@@ -23,7 +23,28 @@ onMounted(async () => {
 	try {
 		// Load the Clippster project into the OpenCut editor via bridge
 		// This initializes EditorCore internally and converts the SQLite project
-		await loadClippsterProject(projectId);
+		const editor = await loadClippsterProject(projectId);
+
+		// Wait for project to be fully loaded and ready
+		// Verify that both project and scene are accessible before rendering
+		let retries = 0;
+		const maxRetries = 50; // 5 seconds max wait
+		while (retries < maxRetries) {
+			const project = editor.project.getActiveOrNull();
+			const scenes = editor.scenes.getScenes();
+			
+			if (project && scenes.length > 0) {
+				// Project and scenes are loaded, safe to render
+				break;
+			}
+			
+			await new Promise(resolve => setTimeout(resolve, 100));
+			retries++;
+		}
+
+		if (retries >= maxRetries) {
+			throw new Error("Timeout waiting for project to load");
+		}
 
 		isLoading.value = false;
 	} catch (err) {

--- a/client/src/services/database/video-editor-projects.ts
+++ b/client/src/services/database/video-editor-projects.ts
@@ -58,11 +58,23 @@ export async function createVideoEditorProject(
   const now = timestamp();
   const userId = getCurrentUserId();
 
-  await db.execute(
-    `INSERT INTO video_editor_projects (id, name, description, thumbnail_path, total_duration, user_id, created_at, updated_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
-    [id, name, description || null, null, 0, userId, now, now]
-  );
+  // Ensure user_id column exists before trying to insert
+  await ensureUserIdColumn();
+
+  if (userIdColumnExists) {
+    await db.execute(
+      `INSERT INTO video_editor_projects (id, name, description, thumbnail_path, total_duration, user_id, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+      [id, name, description || null, null, 0, userId, now, now]
+    );
+  } else {
+    // Fallback for databases without user_id column
+    await db.execute(
+      `INSERT INTO video_editor_projects (id, name, description, thumbnail_path, total_duration, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      [id, name, description || null, null, 0, now, now]
+    );
+  }
 
   return id;
 }
@@ -79,6 +91,16 @@ export async function getVideoEditorProject(id: string): Promise<VideoEditorProj
 export async function getAllVideoEditorProjects(): Promise<VideoEditorProject[]> {
   const db = await getDatabase();
   const userId = getCurrentUserId();
+
+  // Ensure user_id column exists
+  await ensureUserIdColumn();
+
+  if (!userIdColumnExists) {
+    // Fallback: return all projects if user_id column doesn't exist
+    return await db.select<VideoEditorProject[]>(
+      'SELECT * FROM video_editor_projects ORDER BY updated_at DESC'
+    );
+  }
 
   if (userId === null) {
     return await db.select<VideoEditorProject[]>(
@@ -282,6 +304,37 @@ async function ensureKeyframesDataColumn() {
       console.log('[video-editor-projects] Successfully added keyframes_data column');
     } catch (alterError) {
       console.error('[video-editor-projects] Failed to add keyframes_data column:', alterError);
+    }
+  }
+}
+
+// Check if user_id column exists in video_editor_projects, if not add it
+let userIdColumnExists = false;
+async function ensureUserIdColumn() {
+  if (userIdColumnExists) return;
+
+  const db = await getDatabase();
+  try {
+    // Try to query the column - if it fails, it doesn't exist
+    await db.execute('SELECT user_id FROM video_editor_projects LIMIT 1', []);
+    userIdColumnExists = true;
+  } catch (error) {
+    // Column doesn't exist, add it
+    console.log('[video-editor-projects] Adding user_id column to video_editor_projects');
+    try {
+      await db.execute(
+        'ALTER TABLE video_editor_projects ADD COLUMN user_id INTEGER DEFAULT NULL',
+        []
+      );
+      // Create index for faster lookups
+      await db.execute(
+        'CREATE INDEX IF NOT EXISTS idx_video_editor_projects_user_id ON video_editor_projects(user_id)',
+        []
+      );
+      userIdColumnExists = true;
+      console.log('[video-editor-projects] Successfully added user_id column and index');
+    } catch (alterError) {
+      console.error('[video-editor-projects] Failed to add user_id column:', alterError);
     }
   }
 }

--- a/docs/OPENCUT_EDITOR_PRODUCTION_FIXES.md
+++ b/docs/OPENCUT_EDITOR_PRODUCTION_FIXES.md
@@ -1,0 +1,84 @@
+# OpenCut Editor Production Fixes
+
+## Issues Identified
+
+When loading a manually clipped livestream in the OpenCut editor in production, two critical issues occurred:
+
+### 1. CSP Blocking Filmstrip Thumbnails
+**Error**: `Loading the image 'blob:http://tauri.localhost/...' violates the following Content Security Policy directive: "img-src 'self' asset: https://asset.localhost data: https:"`
+
+**Root Cause**: The filmstrip thumbnails are generated as `blob:` URLs by the FilmstripService using mediabunny's `CanvasSink.canvasesAtTimestamps()`. The Content Security Policy in production did not allow `blob:` URLs in the `img-src` directive.
+
+**Fix**: Added `blob:` to the `img-src` CSP directive in `client/src-tauri/tauri.conf.json`:
+```
+img-src 'self' asset: https://asset.localhost data: blob: https:
+```
+
+### 2. Race Condition - "No active project/scene" Errors
+**Errors**:
+```
+Error: No active project
+Error: No active scene
+```
+
+**Root Cause**: The `EditorLayout` component was rendering before the project was fully loaded. The `loadClippsterProject()` function is asynchronous and performs several operations:
+1. Load project from SQLite
+2. Convert to OpenCut format
+3. Save to storage
+4. Load media assets
+5. Initialize scenes
+
+Components in `EditorLayout` immediately call `editor.project.getActive()` and `editor.scenes.getActiveScene()`, which throw errors when called before initialization completes.
+
+**Fix**: Added a polling loop in `OpenCutEditor.vue` to wait for both project and scenes to be fully loaded before rendering `EditorLayout`:
+
+```typescript
+// Wait for project to be fully loaded and ready
+let retries = 0;
+const maxRetries = 50; // 5 seconds max wait
+while (retries < maxRetries) {
+  const project = editor.project.getActiveOrNull();
+  const scenes = editor.scenes.getScenes();
+  
+  if (project && scenes.length > 0) {
+    // Project and scenes are loaded, safe to render
+    break;
+  }
+  
+  await new Promise(resolve => setTimeout(resolve, 100));
+  retries++;
+}
+```
+
+## Files Modified
+
+### `client/src-tauri/tauri.conf.json`
+- **Line 28**: Added `blob:` to `img-src` CSP directive
+- **Line 4**: Bumped version from `0.1.93` to `0.1.94`
+
+### `client/src/pages/OpenCutEditor.vue`
+- **Lines 26-47**: Added project/scene readiness check before rendering EditorLayout
+- Uses `getActiveOrNull()` and `getScenes()` to safely check state
+- Polls every 100ms for up to 5 seconds
+- Throws timeout error if project doesn't load in time
+
+## Expected Behavior After Fix
+
+1. **Filmstrip thumbnails display correctly** - No CSP violations, thumbnails load and render on timeline elements
+2. **No "No active project/scene" errors** - EditorLayout only renders after project is fully initialized
+3. **Smooth editor loading** - Loading spinner shows until both project and scenes are ready
+
+## Testing Recommendations
+
+1. Load a manually clipped livestream in production build
+2. Verify filmstrip thumbnails appear on timeline video elements
+3. Verify no console errors about "No active project" or "No active scene"
+4. Verify editor loads within 5 seconds (or shows timeout error)
+5. Test with different clip sources (VOD clips, uploaded videos, livestream clips)
+
+## Related Systems
+
+- **FilmstripService** (`client/src/editor/services/filmstrip-service.ts`) - Generates blob URLs for thumbnails
+- **ProjectManager** (`client/src/editor/core/managers/project-manager.ts`) - Manages project loading state
+- **ScenesManager** (`client/src/editor/core/managers/scenes-manager.ts`) - Manages scene initialization
+- **Project Loader** (`client/src/editor/bridge/project-loader.ts`) - Converts Clippster projects to OpenCut format


### PR DESCRIPTION
…tor projects

Changes:
- Bump app version from 0.1.92 to 0.1.93 in Cargo.toml and tauri.conf.json
- Add blob: to img-src CSP directive for image loading support
- Add retry logic in OpenCutEditor to wait for project and scenes to load before rendering
- Add ensureUserIdColumn migration function to add user_id column to video_editor_projects table if missing
- Update createVideoEditorProject and getAllVideoEditorProjects to handle