### PR TITLE
Bump version to 0.1.95 and fix macOS production livestream recording …

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -346,10 +346,14 @@ jobs:
           IDENTITY=$(security find-identity -v -p codesigning $KEYCHAIN_PATH | grep "Developer ID Application" | head -1 | awk -F'"' '{print $2}')
           echo "Using identity: $IDENTITY"
           
-          # Sign all .node files in pumpfun-service/node_modules
+          # Sign all .node files in pumpfun-service/node_modules WITH entitlements.
+          # Native .node addons are loaded via dlopen() by Node.js, which hardened
+          # runtime blocks unless disable-library-validation is granted.
+          # Without this, @livekit/rtc-node and other native addons crash on macOS production.
+          NODE_ENTITLEMENTS="client/src-tauri/entitlements/node.entitlements.plist"
           find client/src-tauri/pumpfun-service/node_modules -name "*.node" -type f | while read file; do
-            echo "Signing: $file"
-            codesign --force --options runtime --timestamp --sign "$IDENTITY" "$file"
+            echo "Signing with entitlements: $file"
+            codesign --force --options runtime --timestamp --entitlements "$NODE_ENTITLEMENTS" --sign "$IDENTITY" "$file"
           done
           
           echo "Native modules signed successfully"
@@ -362,17 +366,39 @@ jobs:
             TRIPLE="x86_64-apple-darwin"
           fi
 
-          for BINARY in \
-            "client/src-tauri/binaries/ffmpeg-${TRIPLE}" \
-            "client/src-tauri/binaries/node-${TRIPLE}" \
-            "client/src-tauri/binaries/yt-dlp-${TRIPLE}"; do
-            if [ -f "$BINARY" ]; then
-              echo "Signing sidecar: $BINARY"
-              codesign --force --options runtime --timestamp --sign "$IDENTITY" "$BINARY"
-            else
-              echo "WARNING: Sidecar binary not found: $BINARY"
-            fi
-          done
+          # Sign ffmpeg (native binary - no special entitlements needed)
+          FFMPEG_BINARY="client/src-tauri/binaries/ffmpeg-${TRIPLE}"
+          if [ -f "$FFMPEG_BINARY" ]; then
+            echo "Signing sidecar: $FFMPEG_BINARY"
+            codesign --force --options runtime --timestamp --sign "$IDENTITY" "$FFMPEG_BINARY"
+          else
+            echo "WARNING: Sidecar binary not found: $FFMPEG_BINARY"
+          fi
+
+          # Sign Node.js WITH entitlements - it needs disable-library-validation to
+          # dlopen() native .node addons (e.g., @livekit/rtc-node), and allow-jit
+          # for V8 JIT compilation. Without these, PumpFun recording fails silently.
+          NODE_BINARY="client/src-tauri/binaries/node-${TRIPLE}"
+          NODE_ENTITLEMENTS="client/src-tauri/entitlements/node.entitlements.plist"
+          if [ -f "$NODE_BINARY" ]; then
+            echo "Signing node with entitlements: $NODE_BINARY"
+            codesign --force --options runtime --timestamp --entitlements "$NODE_ENTITLEMENTS" --sign "$IDENTITY" "$NODE_BINARY"
+          else
+            echo "WARNING: Node binary not found: $NODE_BINARY"
+          fi
+
+          # Sign yt-dlp WITH entitlements - it's a PyInstaller binary that needs
+          # disable-library-validation and allow-unsigned-executable-memory to load
+          # its embedded Python runtime under hardened runtime.
+          # Without these entitlements, yt-dlp crashes silently on macOS production.
+          YTDLP_BINARY="client/src-tauri/binaries/yt-dlp-${TRIPLE}"
+          YTDLP_ENTITLEMENTS="client/src-tauri/entitlements/yt-dlp.entitlements.plist"
+          if [ -f "$YTDLP_BINARY" ]; then
+            echo "Signing yt-dlp with entitlements: $YTDLP_BINARY"
+            codesign --force --options runtime --timestamp --entitlements "$YTDLP_ENTITLEMENTS" --sign "$IDENTITY" "$YTDLP_BINARY"
+          else
+            echo "WARNING: yt-dlp binary not found: $YTDLP_BINARY"
+          fi
 
           echo "=== All signing complete ==="
 

--- a/client/src-tauri/Cargo.lock
+++ b/client/src-tauri/Cargo.lock
@@ -719,7 +719,7 @@ dependencies = [
 
 [[package]]
 name = "clippster-ui"
-version = "0.1.92"
+version = "0.1.94"
 dependencies = [
  "async-stream",
  "base64 0.22.1",

--- a/client/src-tauri/Cargo.toml
+++ b/client/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clippster-ui"
-version = "0.1.94"
+version = "0.1.95"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/client/src-tauri/entitlements/node.entitlements.plist
+++ b/client/src-tauri/entitlements/node.entitlements.plist
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <!-- Required for Node.js to dlopen() native .node addons (e.g., @livekit/rtc-node).
+         Without this, hardened runtime blocks loading of dynamically-linked native modules. -->
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+    <!-- Required for Node.js JIT compilation (V8 engine) and native addon memory allocation. -->
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+</dict>
+</plist>

--- a/client/src-tauri/entitlements/yt-dlp.entitlements.plist
+++ b/client/src-tauri/entitlements/yt-dlp.entitlements.plist
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <!-- Required for PyInstaller-built binaries (like yt-dlp) to load their embedded Python runtime.
+         Without this, hardened runtime blocks the dynamic library loading and the binary crashes silently. -->
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+    <!-- Required for PyInstaller to allocate executable memory for the embedded Python interpreter. -->
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+</dict>
+</plist>

--- a/client/src-tauri/src/kick.rs
+++ b/client/src-tauri/src/kick.rs
@@ -570,13 +570,25 @@ async fn run_kick_recorder(
     let ffmpeg_path = resolve_ffmpeg_binary()?;
     let kick_url = format!("https://kick.com/{}", channel_slug);
 
+    // Verify binaries exist on disk before attempting to spawn
+    let ytdlp_exists = std::path::Path::new(&ytdlp_path).exists();
+    let ffmpeg_exists = std::path::Path::new(&ffmpeg_path).exists();
+
     // Log resolved binary paths and output dir for debugging macOS production issues
     let _ = app.emit("recorder-log", KickRecorderLogPayload {
         streamer_id: streamer_id.clone(),
         channel_slug: channel_slug.clone(),
-        message: format!("Resolved binaries - yt-dlp: {}, ffmpeg: {}, output: {}", ytdlp_path, ffmpeg_path, output_dir),
+        message: format!("Resolved binaries - yt-dlp: {} (exists: {}), ffmpeg: {} (exists: {}), output: {}", 
+            ytdlp_path, ytdlp_exists, ffmpeg_path, ffmpeg_exists, output_dir),
         level: "info".to_string(),
     });
+
+    if !ytdlp_exists {
+        return Err(format!("yt-dlp binary not found at: {}", ytdlp_path));
+    }
+    if !ffmpeg_exists {
+        return Err(format!("ffmpeg binary not found at: {}", ffmpeg_path));
+    }
 
     // HLS segment duration in seconds
     // For Auto-Detect/Record: use user-configured segment duration (e.g., 5 minutes = 300 seconds)
@@ -622,7 +634,6 @@ async fn run_kick_recorder(
 
     // CRITICAL: Drain yt-dlp stderr in a background task to prevent pipe buffer deadlock.
     // On macOS, if the stderr pipe buffer fills (~64KB), the child process blocks forever.
-    // This was the root cause of livestream watching not working on macOS.
     if let Some(ytdlp_stderr) = ytdlp_child.stderr.take() {
         let app_for_ytdlp_stderr = app.clone();
         let streamer_id_for_ytdlp = streamer_id.clone();
@@ -632,15 +643,19 @@ async fn run_kick_recorder(
             let mut lines = reader.lines();
             while let Ok(Some(line)) = lines.next_line().await {
                 println!("[KickRecorder] yt-dlp stderr: {}", line);
-                // Emit errors to frontend for visibility
-                if line.contains("ERROR") || line.contains("error") {
-                    let _ = app_for_ytdlp_stderr.emit("recorder-log", KickRecorderLogPayload {
-                        streamer_id: streamer_id_for_ytdlp.clone(),
-                        channel_slug: channel_slug_for_ytdlp.clone(),
-                        message: format!("yt-dlp: {}", line),
-                        level: "error".to_string(),
-                    });
-                }
+                // Emit ALL stderr lines to frontend - not just "error" lines.
+                // PyInstaller crashes (hardened runtime) output "MemoryError",
+                // "Failed to execute script", "Killed", "Traceback" etc.
+                let line_lower = line.to_lowercase();
+                let is_error = line_lower.contains("error") || line_lower.contains("fail")
+                    || line_lower.contains("killed") || line_lower.contains("traceback")
+                    || line_lower.contains("crash") || line_lower.contains("abort");
+                let _ = app_for_ytdlp_stderr.emit("recorder-log", KickRecorderLogPayload {
+                    streamer_id: streamer_id_for_ytdlp.clone(),
+                    channel_slug: channel_slug_for_ytdlp.clone(),
+                    message: format!("yt-dlp stderr: {}", line),
+                    level: if is_error { "error".to_string() } else { "info".to_string() },
+                });
             }
         });
     }

--- a/client/src-tauri/src/twitch.rs
+++ b/client/src-tauri/src/twitch.rs
@@ -582,13 +582,25 @@ async fn run_twitch_recorder(
     let ffmpeg_path = resolve_ffmpeg_binary()?;
     let twitch_url = format!("https://twitch.tv/{}", channel_name);
 
+    // Verify binaries exist on disk before attempting to spawn
+    let ytdlp_exists = std::path::Path::new(&ytdlp_path).exists();
+    let ffmpeg_exists = std::path::Path::new(&ffmpeg_path).exists();
+
     // Log resolved binary paths and output dir for debugging macOS production issues
     let _ = app.emit("recorder-log", TwitchRecorderLogPayload {
         streamer_id: streamer_id.clone(),
         channel_name: channel_name.clone(),
-        message: format!("Resolved binaries - yt-dlp: {}, ffmpeg: {}, output: {}", ytdlp_path, ffmpeg_path, output_dir),
+        message: format!("Resolved binaries - yt-dlp: {} (exists: {}), ffmpeg: {} (exists: {}), output: {}", 
+            ytdlp_path, ytdlp_exists, ffmpeg_path, ffmpeg_exists, output_dir),
         level: "info".to_string(),
     });
+
+    if !ytdlp_exists {
+        return Err(format!("yt-dlp binary not found at: {}", ytdlp_path));
+    }
+    if !ffmpeg_exists {
+        return Err(format!("ffmpeg binary not found at: {}", ffmpeg_path));
+    }
 
     // HLS segment duration in seconds
     // For Auto-Detect/Record: use user-configured segment duration (e.g., 5 minutes = 300 seconds)
@@ -641,14 +653,19 @@ async fn run_twitch_recorder(
             let mut lines = reader.lines();
             while let Ok(Some(line)) = lines.next_line().await {
                 println!("[TwitchRecorder] yt-dlp stderr: {}", line);
-                if line.contains("ERROR") || line.contains("error") {
-                    let _ = app_for_ytdlp_stderr.emit("recorder-log", TwitchRecorderLogPayload {
-                        streamer_id: streamer_id_for_ytdlp.clone(),
-                        channel_name: channel_name_for_ytdlp.clone(),
-                        message: format!("yt-dlp: {}", line),
-                        level: "error".to_string(),
-                    });
-                }
+                // Emit ALL stderr lines to frontend - not just "error" lines.
+                // PyInstaller crashes (hardened runtime) output "MemoryError",
+                // "Failed to execute script", "Killed", "Traceback" etc.
+                let line_lower = line.to_lowercase();
+                let is_error = line_lower.contains("error") || line_lower.contains("fail")
+                    || line_lower.contains("killed") || line_lower.contains("traceback")
+                    || line_lower.contains("crash") || line_lower.contains("abort");
+                let _ = app_for_ytdlp_stderr.emit("recorder-log", TwitchRecorderLogPayload {
+                    streamer_id: streamer_id_for_ytdlp.clone(),
+                    channel_name: channel_name_for_ytdlp.clone(),
+                    message: format!("yt-dlp stderr: {}", line),
+                    level: if is_error { "error".to_string() } else { "info".to_string() },
+                });
             }
         });
     }

--- a/client/src-tauri/tauri.conf.json
+++ b/client/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Clippster",
-  "version": "0.1.94",
+  "version": "0.1.95",
   "identifier": "com.openworth.clippster",
   "build": {
     "beforeDevCommand": "yarn dev",

--- a/client/src/composables/useLivestreamViewer.ts
+++ b/client/src/composables/useLivestreamViewer.ts
@@ -711,6 +711,10 @@ export function useLivestreamViewer() {
         // Start segment polling for clipping functionality
         startSegmentPolling();
 
+        // Listen for segment events and recorder logs (errors, binary paths)
+        // Without this, Kick recording errors are invisible in the WebView console
+        await setupSegmentEventListeners();
+
         // Start playback sync to keep UI in sync with HLS state
         startPlaybackSync();
 
@@ -854,6 +858,10 @@ export function useLivestreamViewer() {
 
         // Start segment polling for clipping functionality
         startSegmentPolling();
+
+        // Listen for segment events and recorder logs (errors, binary paths)
+        // Without this, Twitch recording errors are invisible in the WebView console
+        await setupSegmentEventListeners();
 
         // Start playback sync to keep UI in sync with HLS state
         startPlaybackSync();


### PR DESCRIPTION
…with entitlements and enhanced error logging

Changes:
- Bump app version from 0.1.94 to 0.1.95 in Cargo.toml and tauri.conf.json
- Add entitlements to code signing for Node.js, yt-dlp, and .node native modules in release workflow
- Sign Node.js binary with disable-library-validation and allow-jit entitlements for V8 JIT and native addon loading
- Sign yt-dlp binary with disable-library-validation and allow-unsigned-executable-memory