### PR TITLE
Fix macOS production livestream recording: entitlements, sidecar reso…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -492,6 +492,9 @@ jobs:
 
       # Use tauri-action for all platforms (handles CLI installation efficiently)
       # macOS aarch64: native build, ffmpeg-sys-the-third compiles FFmpeg from source
+      # Tauri-action signs with APPLE_CERTIFICATE but we omit APPLE_ID/PASSWORD/TEAM_ID
+      # to prevent auto-notarization. We re-sign sidecars with entitlements and notarize
+      # manually in a post-build step below.
       - name: Build Tauri App (macOS aarch64)
         if: contains(matrix.platform, 'macos') && contains(matrix.args, 'aarch64')
         uses: tauri-apps/tauri-action@v0
@@ -501,9 +504,6 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         with:
           projectPath: client
           args: ${{ matrix.args }} --features ffmpeg-static
@@ -519,9 +519,6 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           FFMPEG_DIR: ${{ github.workspace }}/client/src-tauri/ffmpeg-x86_64
         with:
           projectPath: client
@@ -541,6 +538,135 @@ jobs:
           projectPath: client
           args: ${{ matrix.args }}
 
+      # Post-build: re-sign sidecars with entitlements, notarize, and re-package.
+      # tauri-action signs everything but strips entitlements from sidecars.
+      # We re-sign node and yt-dlp inside the .app with their entitlements,
+      # then notarize, staple, and re-create the .app.tar.gz + DMG.
+      - name: Re-sign sidecars with entitlements and notarize (macOS)
+        if: contains(matrix.platform, 'macos')
+        env:
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        run: |
+          set -euo pipefail
+
+          # Import certificate into a temporary keychain for signing
+          CERTIFICATE_PATH=$RUNNER_TEMP/postsign_cert.p12
+          KEYCHAIN_PATH=$RUNNER_TEMP/postsign.keychain-db
+          KEYCHAIN_PASSWORD=$(openssl rand -base64 32)
+
+          echo -n "$APPLE_CERTIFICATE" | base64 --decode -o $CERTIFICATE_PATH
+          security create-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+          security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+          security import $CERTIFICATE_PATH -P "$APPLE_CERTIFICATE_PASSWORD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
+          EXISTING_KEYCHAINS=$(security list-keychains -d user | tr -d '"' | tr '\n' ' ')
+          security list-keychains -d user -s $KEYCHAIN_PATH $EXISTING_KEYCHAINS
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+
+          IDENTITY=$(security find-identity -v -p codesigning $KEYCHAIN_PATH | grep "Developer ID Application" | head -1 | awk -F'"' '{print $2}')
+          echo "Using identity: $IDENTITY"
+
+          # Locate the .app bundle
+          APP_BUNDLE=$(find client/src-tauri/target -name "*.app" -type d | head -1)
+          if [ -z "$APP_BUNDLE" ]; then
+            echo "ERROR: .app bundle not found"
+            exit 1
+          fi
+          echo "Found .app bundle: $APP_BUNDLE"
+          MACOS_DIR="$APP_BUNDLE/Contents/MacOS"
+
+          # Entitlements paths
+          NODE_ENTITLEMENTS="client/src-tauri/entitlements/node.entitlements.plist"
+          YTDLP_ENTITLEMENTS="client/src-tauri/entitlements/yt-dlp.entitlements.plist"
+
+          # Re-sign native .node addons inside the bundled pumpfun-service
+          echo "=== Re-signing native .node addons ==="
+          find "$APP_BUNDLE/Contents/Resources" -name "*.node" -type f 2>/dev/null | while read file; do
+            echo "Signing with entitlements: $file"
+            codesign --force --options runtime --timestamp --entitlements "$NODE_ENTITLEMENTS" --sign "$IDENTITY" "$file"
+          done
+
+          # Re-sign node with entitlements (needs disable-library-validation + allow-jit)
+          if [ -f "$MACOS_DIR/node" ]; then
+            echo "Re-signing node with entitlements"
+            codesign --force --options runtime --timestamp --entitlements "$NODE_ENTITLEMENTS" --sign "$IDENTITY" "$MACOS_DIR/node"
+          fi
+
+          # Re-sign yt-dlp with entitlements (PyInstaller binary needs disable-library-validation)
+          if [ -f "$MACOS_DIR/yt-dlp" ]; then
+            echo "Re-signing yt-dlp with entitlements"
+            codesign --force --options runtime --timestamp --entitlements "$YTDLP_ENTITLEMENTS" --sign "$IDENTITY" "$MACOS_DIR/yt-dlp"
+          fi
+
+          # Re-sign the outer .app to update the seal after modifying inner binaries
+          echo "Re-signing .app bundle"
+          codesign --force --deep --options runtime --timestamp --sign "$IDENTITY" "$APP_BUNDLE"
+
+          # Verify entitlements were applied
+          echo "=== Verifying entitlements ==="
+          if [ -f "$MACOS_DIR/node" ]; then
+            codesign -d --entitlements - "$MACOS_DIR/node" 2>&1 || true
+          fi
+          if [ -f "$MACOS_DIR/yt-dlp" ]; then
+            codesign -d --entitlements - "$MACOS_DIR/yt-dlp" 2>&1 || true
+          fi
+
+          # Notarize the .app bundle
+          echo "=== Notarizing .app bundle ==="
+          ZIP_PATH="$RUNNER_TEMP/Clippster-notarize.zip"
+          ditto -c -k --keepParent "$APP_BUNDLE" "$ZIP_PATH"
+          xcrun notarytool submit "$ZIP_PATH" \
+            --apple-id "$APPLE_ID" \
+            --password "$APPLE_PASSWORD" \
+            --team-id "$APPLE_TEAM_ID" \
+            --wait
+          rm -f "$ZIP_PATH"
+
+          # Staple the notarization ticket
+          echo "=== Stapling notarization ticket ==="
+          xcrun stapler staple "$APP_BUNDLE"
+
+          # Re-create the .app.tar.gz for the updater
+          echo "=== Re-creating .app.tar.gz ==="
+          APP_TAR=$(find client/src-tauri/target -name "*.app.tar.gz" -type f | head -1)
+          if [ -n "$APP_TAR" ]; then
+            APP_DIR=$(dirname "$APP_BUNDLE")
+            APP_NAME=$(basename "$APP_BUNDLE")
+            tar -czf "$APP_TAR" -C "$APP_DIR" "$APP_NAME"
+            echo "Re-created: $APP_TAR"
+
+            # Re-sign the .app.tar.gz with Tauri updater signing key
+            echo "=== Re-signing .app.tar.gz with Tauri key ==="
+            TAURI_PRIVATE_KEY_FILE="$RUNNER_TEMP/tauri_key.pem"
+            echo "$TAURI_SIGNING_PRIVATE_KEY" > "$TAURI_PRIVATE_KEY_FILE"
+
+            # Use the tauri CLI to sign the updater bundle
+            npx @tauri-apps/cli signer sign -k "$TAURI_SIGNING_PRIVATE_KEY" -p "$TAURI_SIGNING_PRIVATE_KEY_PASSWORD" "$APP_TAR"
+            rm -f "$TAURI_PRIVATE_KEY_FILE"
+            echo "Re-signed updater bundle: ${APP_TAR}.sig"
+          fi
+
+          # Re-create the DMG
+          echo "=== Re-creating DMG ==="
+          DMG_FILE=$(find client/src-tauri/target -name "*.dmg" -type f | head -1)
+          if [ -n "$DMG_FILE" ]; then
+            APP_DIR=$(dirname "$APP_BUNDLE")
+            APP_NAME=$(basename "$APP_BUNDLE" .app)
+            rm -f "$DMG_FILE"
+            hdiutil create -volname "$APP_NAME" -srcfolder "$APP_BUNDLE" -ov -format UDZO "$DMG_FILE"
+            # Sign the DMG
+            codesign --force --timestamp --sign "$IDENTITY" "$DMG_FILE"
+            echo "Re-created DMG: $DMG_FILE"
+          fi
+
+          echo "=== Post-build signing and notarization complete ==="
+
       - name: Upload artifacts to public releases repo (macOS)
         if: contains(matrix.platform, 'macos')
         shell: bash
@@ -552,7 +678,7 @@ jobs:
           # Upload DMG
           DMG_FILE=$(find client/src-tauri/target -name "*.dmg" -type f | head -1)
           [ -n "$DMG_FILE" ] && gh release upload "v$VERSION" "$DMG_FILE" --repo $RELEASES_REPO --clobber
-          
+
           # Upload .app.tar.gz (for updater) with architecture suffix
           APP_TAR=$(find client/src-tauri/target -name "*.app.tar.gz" -type f | head -1)
           if [ -n "$APP_TAR" ]; then
@@ -560,7 +686,7 @@ jobs:
             NEW_NAME="${BASENAME%.app.tar.gz}_${ARCH_SUFFIX}.app.tar.gz"
             cp "$APP_TAR" "/tmp/$NEW_NAME"
             gh release upload "v$VERSION" "/tmp/$NEW_NAME" --repo $RELEASES_REPO --clobber
-            
+
             # Upload signature
             APP_SIG=$(find client/src-tauri/target -name "*.app.tar.gz.sig" -type f | head -1)
             if [ -n "$APP_SIG" ]; then

--- a/MACOS_LIVE_BUG.md
+++ b/MACOS_LIVE_BUG.md
@@ -1,0 +1,300 @@
+# macOS Production Livestream Watching Bug
+
+**Status:** FIXES IMPLEMENTED - PENDING VERIFICATION
+**Severity:** Critical - All livestream watching broken on macOS production builds
+**Affected:** PumpFun, Kick, Twitch - ALL platforms, macOS production only
+**Works in:** Dev mode (all platforms), Windows production, Linux production
+**Version:** 0.1.95+
+
+---
+
+## Symptom
+
+When watching any livestream on macOS production build, the video never loads. The viewer opens but shows a blank/loading state indefinitely.
+
+### Key Log Evidence
+
+```
+[Error] Refused to connect to ipc://localhost/get_platform because it does not appear in the connect-src directive of the Content Security Policy.
+[Warning] IPC custom protocol failed, Tauri will now use the postMessage interface instead – TypeError: Load failed
+[Debug] [LiveViewer] No segments returned from get_hls_segments (x34+)
+```
+
+The `get_hls_segments` Tauri command returns empty results 34+ times (polled every 2s = ~68 seconds of no segments). This means the output directory either doesn't exist or contains no `.ts` segments and no `.m3u8` playlist.
+
+---
+
+## Architecture Overview
+
+### Livestream Recording Pipeline (per platform)
+
+**PumpFun:**
+1. Frontend calls `start_hls_recording` Tauri command
+2. Rust creates output dir: `~/Library/Application Support/Clippster/videos/hls_live/{mint_id}/{session_id}/`
+3. Rust spawns **Node.js sidecar** via `app.shell().sidecar("node")` with `record-livestream.mjs`
+4. Node.js connects to PumpFun's LiveKit server, receives WebRTC media, pipes to FFmpeg, outputs HLS segments
+
+**Kick/Twitch:**
+1. Frontend calls `start_kick_recording` / `start_twitch_recording`
+2. Rust creates output dir: `~/Library/Application Support/Clippster/livestream_recordings/{session_id}/`
+3. Rust spawns **yt-dlp** (piped to **FFmpeg**) via `tokio::process::Command`
+4. yt-dlp captures stream, FFmpeg re-encodes to HLS segments
+
+### HLS Playback Pipeline
+1. `updateHlsSegments()` polls `get_hls_segments` every 2 seconds
+2. `get_hls_segments` reads the output directory for `.m3u8` playlist and `.ts` files
+3. Once segments exist, hls.js initializes with custom `TauriHlsLoader` (reads files via Tauri IPC)
+4. Video plays in `<video>` element with DVR rewind capability
+
+### Key Files
+- `client/src/composables/useLivestreamViewer.ts` - Main viewer logic, segment polling
+- `client/src/composables/useHlsPlayback.ts` - hls.js configuration and playback
+- `client/src/composables/useTauriHlsLoader.ts` - Custom HLS loader using Tauri IPC
+- `client/src/components/LivestreamWatchDialog.vue` - Watch dialog UI
+- `client/src-tauri/src/hls.rs` - `start_hls_recording`, `get_hls_segments` commands
+- `client/src-tauri/src/hls_proxy.rs` - `read_hls_playlist`, `read_hls_segment` commands
+- `client/src-tauri/src/kick.rs` - Kick recording with yt-dlp + FFmpeg, `resolve_sidecar_binary()`
+- `client/src-tauri/src/twitch.rs` - Twitch recording with yt-dlp + FFmpeg
+- `client/src-tauri/pumpfun-service/record-livestream.mjs` - Node.js LiveKit recorder
+- `client/src-tauri/tauri.conf.json` - CSP and security config
+- `client/src-tauri/entitlements/node.entitlements.plist` - Node.js hardened runtime entitlements (NOT APPLIED)
+- `client/src-tauri/entitlements/yt-dlp.entitlements.plist` - yt-dlp hardened runtime entitlements (NOT APPLIED)
+
+---
+
+## CONFIRMED Root Causes
+
+### Root Cause 1: Entitlements NOT Applied - Sidecar Binaries Crash (CONFIRMED)
+
+**Entitlements check (`codesign -d --entitlements -`) shows ZERO entitlements on ALL binaries:**
+- `clippster-ui` - No entitlements
+- `node` - No entitlements (needs `allow-jit`, `disable-library-validation`, `allow-unsigned-executable-memory`)
+- `yt-dlp` - No entitlements (needs `disable-library-validation`, `allow-unsigned-executable-memory`)
+- `ffmpeg` - No entitlements (doesn't need any - static binary)
+
+All binaries ARE signed with hardened runtime (`flags=0x10000(runtime)`) by `Developer ID Application: OpenWorth Technologies, LLC (CD2RXM358N)`.
+
+The entitlements `.plist` files exist in `client/src-tauri/entitlements/` but are **never referenced by any build script, CI config, or Tauri config**. They are dead files.
+
+#### Node.js Crash (kills PumpFun recording)
+
+```
+$ /Applications/Clippster.app/Contents/MacOS/node -e "console.log(1+1)"
+
+#
+# Fatal process OOM in Failed to reserve virtual memory for CodeRange
+#
+
+Exit code: 133
+```
+
+V8 JIT engine cannot allocate executable memory for its CodeRange without `com.apple.security.cs.allow-jit`. Node.js crashes **immediately** on ANY JavaScript execution. Even `node -e "1+1"` fails. Only `node --version` works (no JS execution).
+
+#### yt-dlp Crash (kills Kick/Twitch recording)
+
+```
+$ /Applications/Clippster.app/Contents/MacOS/yt-dlp --version
+
+[PYI-9617:ERROR] Failed to load Python shared library
+'...Python.framework/Versions/3.14/Python' not valid for use in process:
+mapping process and mapped file (non-platform) have different Team IDs
+```
+
+PyInstaller extracts Python runtime to temp dir. Without `com.apple.security.cs.disable-library-validation`, macOS blocks loading the extracted Python library because it has a different Team ID than the signed yt-dlp binary.
+
+#### FFmpeg Works
+
+```
+$ /Applications/Clippster.app/Contents/MacOS/ffmpeg -version
+ffmpeg version 6.0 Copyright (c) 2000-2023 the FFmpeg developers
+```
+
+Static binary, no JIT or dynamic library loading needed. Works fine under hardened runtime.
+
+### Root Cause 2: Binary Naming Mismatch in Bundle (CONFIRMED)
+
+**`resolve_sidecar_binary()` in `kick.rs:299` expects triple-suffixed names, but bundle has bare names:**
+
+| Expected by code | Actual in bundle |
+|---|---|
+| `ffmpeg-aarch64-apple-darwin` | `ffmpeg` |
+| `yt-dlp-aarch64-apple-darwin` | `yt-dlp` |
+| `node-aarch64-apple-darwin` | `node` |
+
+Tauri strips the target triple suffix when bundling sidecars into the `.app`. The custom `resolve_sidecar_binary()` doesn't account for this. It falls back to returning the bare name (e.g., `"ffmpeg"`), but then `Path::new("ffmpeg").exists()` fails because it's a relative path that doesn't match any file in the working directory.
+
+**Impact:** Even if yt-dlp/ffmpeg were properly entitled, Kick/Twitch recording would STILL fail because the binaries can't be found by `resolve_sidecar_binary()`.
+
+**Note:** PumpFun's Node.js sidecar uses `app.shell().sidecar("node")` (Tauri's API) which handles the naming correctly. Kick/Twitch use the custom `resolve_sidecar_binary()` which does not.
+
+### Root Cause 3: CSP Missing `ipc://localhost` (CONFIRMED - Secondary)
+
+**The error:**
+```
+Refused to connect to ipc://localhost/get_platform because it does not appear in the connect-src directive of the Content Security Policy.
+```
+
+CSP has `http://ipc.localhost` but macOS production uses `ipc://localhost` protocol scheme. Tauri falls back to `postMessage` interface. This is a performance/reliability issue but NOT the primary cause of the segment failure (sidecar spawning happens on the Rust side, not via IPC).
+
+---
+
+## Diagnostic Results
+
+### Step 1: Binary Existence in Bundle
+```
+$ ls -la /Applications/Clippster.app/Contents/MacOS/
+clippster-ui    53MB   (main app)
+ffmpeg          45MB   (static binary - WORKS)
+node            93MB   (V8 JIT binary - CRASHES)
+yt-dlp          36MB   (PyInstaller binary - CRASHES)
+```
+Binaries present but named WITHOUT target triple suffix.
+
+### Step 2: Entitlements Check
+```
+$ codesign -d --entitlements - /Applications/Clippster.app/Contents/MacOS/node
+Executable=/Applications/Clippster.app/Contents/MacOS/node
+(NO ENTITLEMENTS OUTPUT - empty)
+```
+Same for all binaries. Zero entitlements applied.
+
+### Step 3: Codesign Details
+All binaries signed with:
+- Authority: `Developer ID Application: OpenWorth Technologies, LLC (CD2RXM358N)`
+- Hardened runtime: `flags=0x10000(runtime)` - **ENABLED**
+- Properly validated
+
+### Step 4: Direct Binary Execution Tests
+| Binary | Command | Result |
+|---|---|---|
+| `node` | `--version` | `v20.11.0` (no JS executed) |
+| `node` | `-e "console.log(1)"` | `Fatal process OOM in Failed to reserve virtual memory for CodeRange` (exit 133) |
+| `yt-dlp` | `--version` | `[PYI-9617:ERROR] Failed to load Python shared library ... different Team IDs` |
+| `ffmpeg` | `-version` | `ffmpeg version 6.0` (works) |
+
+### Step 5: Bundle Resources
+```
+$ ls /Applications/Clippster.app/Contents/Resources/pumpfun-service/
+fetch-clips.mjs
+node_modules/
+record-livestream.mjs
+package.json
+...
+```
+PumpFun service scripts are present in the bundle.
+
+---
+
+## Required Fixes
+
+### Fix 1: Apply Entitlements During Build (CRITICAL)
+
+The entitlements `.plist` files exist but must be applied during codesigning. After `tauri build` completes the bundle, re-sign the sidecar binaries with entitlements:
+
+```bash
+# Re-sign node with JIT + library validation entitlements
+codesign --force --options runtime --sign "$APPLE_SIGNING_IDENTITY" \
+  --entitlements src-tauri/entitlements/node.entitlements.plist \
+  "target/release/bundle/macos/Clippster.app/Contents/MacOS/node"
+
+# Re-sign yt-dlp with library validation entitlements
+codesign --force --options runtime --sign "$APPLE_SIGNING_IDENTITY" \
+  --entitlements src-tauri/entitlements/yt-dlp.entitlements.plist \
+  "target/release/bundle/macos/Clippster.app/Contents/MacOS/yt-dlp"
+```
+
+This must happen AFTER Tauri bundles the app but BEFORE notarization.
+
+**Implementation options:**
+- Add a post-build script that runs after `tauri build`
+- Use Tauri's `beforeBundleCommand` or a custom build hook
+- Add to CI/CD pipeline after the build step
+
+### Fix 2: Fix Binary Path Resolution for Kick/Twitch (CRITICAL)
+
+`resolve_sidecar_binary()` in `kick.rs:299` looks for `{name}-{target_triple}` but the production bundle has just `{name}`. Fix:
+
+```rust
+fn resolve_sidecar_binary(base_name: &str) -> Result<String, String> {
+    let exe_path = std::env::current_exe()
+        .map_err(|e| format!("Failed to get executable path: {}", e))?;
+    let exe_dir = exe_path.parent().ok_or("Failed to get parent directory")?;
+    let target_triple = get_target_triple();
+
+    // Try triple-suffixed name first (dev mode)
+    #[cfg(target_os = "windows")]
+    let binary_name_with_triple = format!("{}-{}.exe", base_name, target_triple);
+    #[cfg(not(target_os = "windows"))]
+    let binary_name_with_triple = format!("{}-{}", base_name, target_triple);
+
+    let prod_path = exe_dir.join(&binary_name_with_triple);
+    if prod_path.exists() {
+        return Ok(prod_path.to_string_lossy().to_string());
+    }
+
+    // Try bare name (production macOS bundle - Tauri strips the triple)
+    #[cfg(target_os = "windows")]
+    let bare_name = format!("{}.exe", base_name);
+    #[cfg(not(target_os = "windows"))]
+    let bare_name = base_name.to_string();
+
+    let bare_path = exe_dir.join(&bare_name);
+    if bare_path.exists() {
+        return Ok(bare_path.to_string_lossy().to_string());
+    }
+
+    // Development mode: check src-tauri/binaries/
+    // ... (existing dev fallback logic)
+
+    Err(format!("Binary '{}' not found in bundle or PATH", base_name))
+}
+```
+
+The same fix is needed in `twitch.rs` if it has a similar `resolve_sidecar_binary()`.
+
+### Fix 3: Add `ipc://localhost` to CSP (RECOMMENDED)
+
+In `tauri.conf.json`, add `ipc://localhost` to `connect-src`:
+
+```
+connect-src 'self' asset: https://asset.localhost tauri: http://ipc.localhost ipc://localhost http://localhost:* ...
+```
+
+Prevents the IPC fallback to `postMessage` and eliminates the CSP warning.
+
+### Fix 4: Add Sidecar Failure Detection (RECOMMENDED)
+
+Currently, `start_hls_recording` returns `Ok(...)` immediately after spawning. If Node.js crashes (exit 133), the frontend never knows. Consider:
+1. Emit a `recorder-error` event when the sidecar process exits with non-zero code
+2. Frontend should listen for this and show a meaningful error to the user
+3. Optionally: wait for first stdout line before returning success from `start_hls_recording`
+
+---
+
+## Fix History
+
+| Date | Version | Change | Result |
+|------|---------|--------|--------|
+| v0.1.95 | d75abf02 | Added entitlements `.plist` files to repo | Files created but never applied during build. Node.js and yt-dlp still crash. |
+| v0.1.95 | pending | Fix 1: CI post-build re-sign with entitlements + notarize | Removes auto-notarize from tauri-action, adds manual re-sign/notarize step |
+| v0.1.95 | pending | Fix 2: Bare-name sidecar fallback in kick.rs, twitch.rs, sidecar/mod.rs | Resolves binary naming mismatch in macOS `.app` bundle |
+| v0.1.95 | pending | Fix 3: Added `ipc://localhost` to CSP connect-src | Prevents IPC fallback to postMessage |
+
+---
+
+## Investigation State
+
+- [x] Identified symptom: `get_hls_segments` returns empty arrays
+- [x] Traced recording pipeline for all platforms
+- [x] Found entitlements files exist but are not referenced by build system
+- [x] Found CSP mismatch (`http://ipc.localhost` vs `ipc://localhost`)
+- [x] Verified sidecar binary existence in production .app bundle (present, bare names)
+- [x] Checked actual codesign entitlements on production binaries (ZERO entitlements on all)
+- [x] Confirmed Node.js crashes: `Fatal process OOM in Failed to reserve virtual memory for CodeRange` (exit 133)
+- [x] Confirmed yt-dlp crashes: `Failed to load Python shared library ... different Team IDs`
+- [x] Confirmed ffmpeg works (static binary, no entitlements needed)
+- [x] Confirmed binary naming mismatch (`resolve_sidecar_binary()` looks for triple suffix, bundle has bare names)
+- [x] Apply Fix 1: Entitlements during build — CI post-build re-sign step added to `.github/workflows/release.yml`
+- [x] Apply Fix 2: Binary path resolution — Bare-name fallback added to `kick.rs`, `twitch.rs`, `sidecar/mod.rs`
+- [x] Apply Fix 3: CSP fix — Added `ipc://localhost` to `connect-src` in `tauri.conf.json`
+- [ ] Rebuild, re-sign, and verify

--- a/client/src-tauri/Cargo.lock
+++ b/client/src-tauri/Cargo.lock
@@ -719,7 +719,7 @@ dependencies = [
 
 [[package]]
 name = "clippster-ui"
-version = "0.1.94"
+version = "0.1.95"
 dependencies = [
  "async-stream",
  "base64 0.22.1",

--- a/client/src-tauri/Cargo.toml
+++ b/client/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clippster-ui"
-version = "0.1.95"
+version = "0.1.96"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/client/src-tauri/src/kick.rs
+++ b/client/src-tauri/src/kick.rs
@@ -319,6 +319,18 @@ fn resolve_sidecar_binary(base_name: &str) -> Result<String, String> {
         return Ok(prod_path.to_string_lossy().to_string());
     }
 
+    // macOS production bundle: Tauri strips the target triple from sidecar names
+    #[cfg(target_os = "windows")]
+    let bare_name = format!("{}.exe", base_name);
+    #[cfg(not(target_os = "windows"))]
+    let bare_name = base_name.to_string();
+
+    let bare_path = exe_dir.join(&bare_name);
+    if bare_path.exists() {
+        println!("[Kick] Found {} at (bundle): {}", base_name, bare_path.display());
+        return Ok(bare_path.to_string_lossy().to_string());
+    }
+
     // Development mode: check src-tauri/binaries/
     // In dev, exe is in target/debug/, binaries are in src-tauri/binaries/
     if let Some(target_dir) = exe_dir.parent() {

--- a/client/src-tauri/src/sidecar/mod.rs
+++ b/client/src-tauri/src/sidecar/mod.rs
@@ -48,6 +48,18 @@ fn resolve_node_binary() -> Result<String, String> {
         return Ok(prod_path.to_string_lossy().to_string());
     }
 
+    // macOS production bundle: Tauri strips the target triple from sidecar names
+    #[cfg(target_os = "windows")]
+    let bare_name = "node.exe".to_string();
+    #[cfg(not(target_os = "windows"))]
+    let bare_name = "node".to_string();
+
+    let bare_path = exe_dir.join(&bare_name);
+    if bare_path.exists() {
+        println!("[RemotionSidecar] Found node at (bundle): {}", bare_path.display());
+        return Ok(bare_path.to_string_lossy().to_string());
+    }
+
     // Development mode: check src-tauri/binaries/
     if let Some(target_dir) = exe_dir.parent() {
         if let Some(target_parent) = target_dir.parent() {

--- a/client/src-tauri/src/twitch.rs
+++ b/client/src-tauri/src/twitch.rs
@@ -375,6 +375,18 @@ fn resolve_sidecar_binary(base_name: &str) -> Result<String, String> {
         return Ok(prod_path.to_string_lossy().to_string());
     }
 
+    // macOS production bundle: Tauri strips the target triple from sidecar names
+    #[cfg(target_os = "windows")]
+    let bare_name = format!("{}.exe", base_name);
+    #[cfg(not(target_os = "windows"))]
+    let bare_name = base_name.to_string();
+
+    let bare_path = exe_dir.join(&bare_name);
+    if bare_path.exists() {
+        println!("[Twitch] Found {} at (bundle): {}", base_name, bare_path.display());
+        return Ok(bare_path.to_string_lossy().to_string());
+    }
+
     // Development mode: check src-tauri/binaries/
     if let Some(target_dir) = exe_dir.parent() {
         if let Some(target_parent) = target_dir.parent() {

--- a/client/src-tauri/tauri.conf.json
+++ b/client/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Clippster",
-  "version": "0.1.95",
+  "version": "0.1.96",
   "identifier": "com.openworth.clippster",
   "build": {
     "beforeDevCommand": "yarn dev",
@@ -25,7 +25,7 @@
     ],
     "macOSPrivateApi": true,
     "security": {
-      "csp": "default-src 'self' asset: https://asset.localhost; connect-src 'self' asset: https://asset.localhost tauri: http://ipc.localhost http://localhost:* http://127.0.0.1:* https://clippster-server.fly.dev https: wss:; img-src 'self' asset: https://asset.localhost data: blob: https:; media-src 'self' asset: https://asset.localhost tauri: blob: https: http://localhost:* http://127.0.0.1:*; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:",
+      "csp": "default-src 'self' asset: https://asset.localhost; connect-src 'self' asset: https://asset.localhost tauri: http://ipc.localhost ipc://localhost http://localhost:* http://127.0.0.1:* https://clippster-server.fly.dev https: wss:; img-src 'self' asset: https://asset.localhost data: blob: https:; media-src 'self' asset: https://asset.localhost tauri: blob: https: http://localhost:* http://127.0.0.1:*; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:",
       "dangerousDisableAssetCspModification": [
         ".*/.*"
       ],


### PR DESCRIPTION
…lution, and CSP

Three root causes fixed:
- Add bare-name fallback to sidecar binary resolution in kick.rs, twitch.rs, and sidecar/mod.rs since Tauri strips the target triple when bundling into .app
- Add ipc://localhost to CSP connect-src to prevent IPC fallback to postMessage
- Rework CI release workflow to re-sign sidecars with entitlements post-build and manually notarize, since tauri-action strips entitlements during bundling