### PR TITLE
Bump version to 0.2.2 and revert media loading to localhost video ser…

### DIFF
--- a/client/src-tauri/Cargo.toml
+++ b/client/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clippster-ui"
-version = "0.2.1"
+version = "0.2.2"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/client/src-tauri/tauri.conf.json
+++ b/client/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Clippster",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "identifier": "com.openworth.clippster",
   "build": {
     "beforeDevCommand": "yarn dev",

--- a/client/src/editor/bridge/project-loader.ts
+++ b/client/src/editor/bridge/project-loader.ts
@@ -6,7 +6,7 @@
  * with media assets and timeline elements.
  */
 
-import { convertFileSrc } from "@tauri-apps/api/core";
+import { invoke } from "@tauri-apps/api/core";
 import { EditorCore } from "../core";
 import { storageService } from "../storage/service";
 import type { TProject, TProjectSettings } from "../types/project";
@@ -236,18 +236,24 @@ async function buildMediaAssetsFromSources(
 	sources: VideoEditorSource[],
 ): Promise<MediaAsset[]> {
 	const assets: MediaAsset[] = [];
+	let videoServerPort: number;
+
+	try {
+		videoServerPort = await invoke<number>("get_video_server_port");
+	} catch {
+		videoServerPort = 8642;
+	}
 
 	for (const source of sources) {
 		if (!source.source_path) continue;
 
 		const mediaType = inferMediaType(source.source_path);
-		const url = convertFileSrc(source.source_path);
+		const encodedPath = btoa(source.source_path);
+		const url = `http://localhost:${videoServerPort}/video/${encodedPath}`;
 
 		const file = new File([], source.source_name || "source", {
 			type: mediaType === "video" ? "video/mp4" : mediaType === "audio" ? "audio/mpeg" : "image/jpeg",
 		});
-
-		const dims = await probeMediaDimensions(url, mediaType);
 
 		assets.push({
 			id: source.id,
@@ -255,8 +261,8 @@ async function buildMediaAssetsFromSources(
 			type: mediaType,
 			file,
 			url,
-			width: dims?.width,
-			height: dims?.height,
+			width: undefined,
+			height: undefined,
 			duration: source.source_duration ?? undefined,
 			fps: undefined,
 			thumbnailUrl: source.source_thumbnail ?? undefined,

--- a/client/src/editor/storage/tauri-storage-adapter.ts
+++ b/client/src/editor/storage/tauri-storage-adapter.ts
@@ -539,22 +539,66 @@ class TauriStorageService {
 
 	/**
 	 * Create a File object from a filesystem path.
-	 * Uses Tauri's asset protocol (convertFileSrc → https://asset.localhost/...)
-	 * which is same-origin with tauri.localhost and not subject to Chromium's
-	 * Private Network Access policy that blocks http://localhost fetches.
+	 * Uses the Rust video server which has no scope restrictions.
+	 * For large files (>50MB), the server requires Range requests,
+	 * so we use HEAD first to determine size and avoid 416 errors.
 	 */
 	private async fileFromPath(filePath: string, name: string): Promise<File> {
-		const { convertFileSrc } = await import("@tauri-apps/api/core");
-		const mimeType = this.mimeFromPath(filePath);
-
-		const assetUrl = convertFileSrc(filePath);
-		const response = await fetch(assetUrl);
-		if (!response.ok) {
-			throw new Error(`Failed to load file via asset protocol (${response.status}): ${filePath}`);
+		const { invoke } = await import("@tauri-apps/api/core");
+		let videoServerPort: number;
+		try {
+			videoServerPort = await invoke<number>("get_video_server_port");
+		} catch {
+			videoServerPort = 8642;
 		}
-		const blob = await response.blob();
-		return new File([blob], name, {
-			type: blob.type || mimeType,
+
+		const encodedPath = btoa(filePath);
+		const serverUrl = `http://localhost:${videoServerPort}/video/${encodedPath}`;
+
+		// Use HEAD to determine file size before fetching
+		const headResp = await fetch(serverUrl, { method: "HEAD" });
+		if (!headResp.ok) {
+			throw new Error(`Failed to HEAD file from video server (${headResp.status}): ${filePath}`);
+		}
+		const fileSize = parseInt(headResp.headers.get("Content-Length") || "0", 10);
+		if (fileSize === 0) {
+			throw new Error(`Cannot determine file size for: ${filePath}`);
+		}
+
+		const mimeType = this.mimeFromPath(filePath);
+		const MAX_SIMPLE_SIZE = 50 * 1024 * 1024; // 50MB
+
+		// Small files: simple fetch
+		if (fileSize <= MAX_SIMPLE_SIZE) {
+			const response = await fetch(serverUrl);
+			if (!response.ok) {
+				throw new Error(`Failed to load file from video server (${response.status}): ${filePath}`);
+			}
+			const blob = await response.blob();
+			return new File([blob], name, {
+				type: blob.type || mimeType,
+				lastModified: Date.now(),
+			});
+		}
+
+		// Large files: fetch in chunks via Range requests
+		const CHUNK_SIZE = MAX_SIMPLE_SIZE;
+		const chunks: Blob[] = [];
+
+		for (let start = 0; start < fileSize; start += CHUNK_SIZE) {
+			const end = Math.min(start + CHUNK_SIZE - 1, fileSize - 1);
+			const chunkResp = await fetch(serverUrl, {
+				headers: { Range: `bytes=${start}-${end}` },
+			});
+			if (!chunkResp.ok && chunkResp.status !== 206) {
+				throw new Error(`Failed to fetch chunk ${start}-${end} (${chunkResp.status}): ${filePath}`);
+			}
+			chunks.push(await chunkResp.blob());
+		}
+
+		const fullBlob = new Blob(chunks, { type: mimeType });
+		return new File([fullBlob], name, {
+			type: mimeType,
 			lastModified: Date.now(),
 		});
 	}

--- a/client/src/pages/admin/AdminBugReports.vue
+++ b/client/src/pages/admin/AdminBugReports.vue
@@ -582,6 +582,7 @@
     margin: 0.25rem 0 0;
     display: -webkit-box;
     -webkit-line-clamp: 2;
+    line-clamp: 2;
     -webkit-box-orient: vertical;
     overflow: hidden;
     white-space: normal;

--- a/client/src/pages/admin/AdminOrganizations.vue
+++ b/client/src/pages/admin/AdminOrganizations.vue
@@ -936,6 +936,7 @@
     text-overflow: ellipsis;
     display: -webkit-box;
     -webkit-line-clamp: 1;
+    line-clamp: 1;
     -webkit-box-orient: vertical;
   }
 


### PR DESCRIPTION
…ver with chunked fetch for large files

Changes:
- Bump version from 0.2.1 to 0.2.2 in Cargo.toml and tauri.conf.json
- Revert project-loader.ts to use localhost video server URL instead of convertFileSrc
- Remove probeMediaDimensions call and set width/height to undefined in buildMediaAssetsFromSources
- Rewrite fileFromPath in tauri-storage-adapter.ts to use localhost video server with HEAD request for file size
- Add chunked fetch logic for files