### PR TITLE
Fix video editor CORS: add tauri-plugin-localhost to serve frontend f…

### DIFF
--- a/client/src-tauri/src/lib.rs
+++ b/client/src-tauri/src/lib.rs
@@ -740,7 +740,6 @@ pub fn run() {
                 .decorations(false)
                 .visible(false)
                 .transparent(true)
-                .drag_and_drop(false)
                 .build()
                 .expect("Failed to create main window");
 


### PR DESCRIPTION
…rom http://localhost:1420 in production

WebView2's Chromium auto-update started enforcing Private Network Access (PNA) policy, blocking fetches from http://tauri.localhost to http://localhost:48276 (video server). By serving the frontend from http://localhost:1420 via tauri-plugin-localhost, all video server fetches become loopback-to-loopback which PNA allows.

Changes:
- Add tauri-plugin-localhost = 2 to Cargo.toml
- Initialize localhost plugin on port 1420 in lib.rs
- Create main window programmatically: External(http://localhost:1420) in prod, App(/) in dev
- Remove static main window from tauri.conf.json (now created in Rust setup)