### PR TITLE
Update clippster-ui version to 0.1.204 in Cargo.toml, Cargo.lock, and…

### DIFF
--- a/client/src-tauri/Cargo.lock
+++ b/client/src-tauri/Cargo.lock
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "clippster-ui"
-version = "0.1.202"
+version = "0.1.204"
 dependencies = [
  "async-stream",
  "base64 0.22.1",

--- a/client/src-tauri/Cargo.toml
+++ b/client/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clippster-ui"
-version = "0.1.202"
+version = "0.1.204"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/client/src-tauri/tauri.conf.json
+++ b/client/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Clippster",
-  "version": "0.1.202",
+  "version": "0.1.204",
   "identifier": "com.openworth.clippster",
   "build": {
     "beforeDevCommand": "yarn dev",


### PR DESCRIPTION
… tauri.conf.json

- Bumped the version of the clippster-ui package to 0.1.204 across relevant configuration files, ensuring consistency in versioning for the application.