### PR TITLE
Update FFmpeg build reference and bump clippster-ui version to 0.1.209

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -462,10 +462,10 @@ jobs:
           New-Item -ItemType Directory -Force -Path $ffmpegDevDir | Out-Null
           Write-Host "Downloading FFmpeg 8.0 shared build for dev libraries..."
           $zipPath = "$env:RUNNER_TEMP/ffmpeg-shared.zip"
-          # Pinned to a specific immutable autobuild tag (the last BtbN release containing the n8.0
-          # branch before it was dropped). Do NOT change to "latest" — the rolling latest tag now
-          # ships FFmpeg 8.1 headers which break the ffmpeg-the-third 4.x crate (FFmpeg 8.0 only).
-          Invoke-WebRequest -Uri "https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2026-03-29-13-01/ffmpeg-n8.0.1-76-gfa4ee7ab3c-win64-gpl-shared-8.0.zip" -OutFile $zipPath
+          # Pinned to a specific immutable autobuild tag (autobuild-2025-09-30-13-19).
+          # Do NOT change to "latest" — the rolling latest tag now ships FFmpeg 8.1+ headers
+          # which break the ffmpeg-the-third 4.x crate (FFmpeg 8.0 only).
+          Invoke-WebRequest -Uri "https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2025-09-30-13-19/ffmpeg-n8.0-16-gd8605a6b55-win64-gpl-shared-8.0.zip" -OutFile $zipPath
           Expand-Archive -Path $zipPath -DestinationPath $ffmpegDevDir -Force
           Remove-Item $zipPath
           $extractedDir = (Get-ChildItem $ffmpegDevDir -Directory | Select-Object -First 1).FullName

--- a/client/src-tauri/Cargo.lock
+++ b/client/src-tauri/Cargo.lock
@@ -761,7 +761,7 @@ dependencies = [
 
 [[package]]
 name = "clippster-ui"
-version = "0.1.208"
+version = "0.1.209"
 dependencies = [
  "aes",
  "async-stream",

--- a/client/src-tauri/Cargo.toml
+++ b/client/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clippster-ui"
-version = "0.1.208"
+version = "0.1.209"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/client/src-tauri/tauri.conf.json
+++ b/client/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Clippster",
-  "version": "0.1.208",
+  "version": "0.1.209",
   "identifier": "com.openworth.clippster",
   "build": {
     "beforeDevCommand": "yarn dev",

--- a/landing/src/pages/OrgPublicProfilePage.tsx
+++ b/landing/src/pages/OrgPublicProfilePage.tsx
@@ -5,7 +5,6 @@ import {
   Building2,
   CheckCircle2,
   Eye,
-  FileText,
   Globe,
   Link,
   Loader2,
@@ -207,7 +206,7 @@ export function OrgPublicProfilePage() {
                             {s.profile_image_url ? <img src={s.profile_image_url} className="creator-card__avatar-img" /> : <UserCircle className="creator-card__avatar-fallback" />}
                           </div>
                           <span className="creator-card__name">{s.display_name || s.name || 'Streamer'}</span>
-                          <div className="creator-card__platform" title={s.platform ? platformTitle(s.platform) : 'No platform linked'}>
+                          <div className="creator-card__platform" title={s.platform ? platformLabel(s.platform) : 'No platform linked'}>
                             {s.platform && getPlatformIcon(s.platform) ? <img src={getPlatformIcon(s.platform) || ''} className="creator-card__platform-icon" style={{ filter: getPlatformFilter(s.platform) }} /> : <Link className="creator-card__platform-empty" />}
                           </div>
                         </div>
@@ -230,7 +229,7 @@ export function OrgPublicProfilePage() {
                       <div className="org-account__info">
                         <span className="org-account__name">{a.display_name || a.username || a.platform}</span>
                         <div className="org-account__platform-row">
-                          <span className="org-account__platform-chip" title={a.platform ? platformTitle(a.platform) : 'No platform linked'}>
+                          <span className="org-account__platform-chip" title={a.platform ? platformLabel(a.platform) : 'No platform linked'}>
                             {a.platform && getPlatformIcon(a.platform) ? <img src={getPlatformIcon(a.platform) || ''} className="org-account__platform-icon" style={{ filter: getPlatformFilter(a.platform) }} /> : <Link className="org-account__platform-empty" />}
                           </span>
                           <span className="org-account__platform">{platformLabel(a.platform)}</span>


### PR DESCRIPTION
- Changed the FFmpeg download URL in the release workflow to a new immutable autobuild tag.
- Updated clippster-ui version to 0.1.209 in Cargo.toml and Cargo.lock files.
- Modified OrgPublicProfilePage to use consistent platform label functions for improved clarity.