### PR TITLE
chore: update clippster-ui version to 0.1.226 in Cargo.toml and Cargo…

### DIFF
--- a/client/src-tauri/Cargo.lock
+++ b/client/src-tauri/Cargo.lock
@@ -761,7 +761,7 @@ dependencies = [
 
 [[package]]
 name = "clippster-ui"
-version = "0.1.224"
+version = "0.1.226"
 dependencies = [
  "aes",
  "async-stream",

--- a/client/src-tauri/Cargo.toml
+++ b/client/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clippster-ui"
-version = "0.1.224"
+version = "0.1.226"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/client/src-tauri/tauri.conf.json
+++ b/client/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Clippster",
-  "version": "0.1.224",
+  "version": "0.1.226",
   "identifier": "com.openworth.clippster",
   "build": {
     "beforeDevCommand": "yarn dev",


### PR DESCRIPTION
….lock

- Bumped the version number for clippster-ui from 0.1.224 to 0.1.226 in both Cargo.toml and Cargo.lock files to ensure consistency across project dependencies.