### PR TITLE
feat: enhance export functionality with selected elements range

### DIFF
--- a/client/src-tauri/Cargo.lock
+++ b/client/src-tauri/Cargo.lock
@@ -761,7 +761,7 @@ dependencies = [
 
 [[package]]
 name = "clippster-ui"
-version = "0.1.239"
+version = "0.1.240"
 dependencies = [
  "aes",
  "async-stream",

--- a/client/src-tauri/Cargo.toml
+++ b/client/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clippster-ui"
-version = "0.1.239"
+version = "0.1.240"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/client/src-tauri/src/dvr.rs
+++ b/client/src-tauri/src/dvr.rs
@@ -637,7 +637,7 @@ pub async fn build_vod_from_dvr(
     args.extend_from_slice(&[
         "-r".to_string(),
         "30".to_string(), // Force constant 30fps output
-        "-vsync".to_string(),
+        "-fps_mode".to_string(),
         "cfr".to_string(), // Constant frame rate
         "-c:a".to_string(),
         "aac".to_string(),

--- a/client/src-tauri/src/video_editor_export.rs
+++ b/client/src-tauri/src/video_editor_export.rs
@@ -4017,7 +4017,7 @@ pub async fn export_video_editor_project(
 
     args.push("1".to_string());
 
-    args.push("-vsync".to_string());
+    args.push("-fps_mode".to_string());
 
     args.push("cfr".to_string());
 

--- a/client/src-tauri/tauri.conf.json
+++ b/client/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Clippster",
-  "version": "0.1.239",
+  "version": "0.1.240",
   "identifier": "com.openworth.clippster",
   "build": {
     "beforeDevCommand": "yarn dev",

--- a/client/src/editor/components/ExportButton.vue
+++ b/client/src/editor/components/ExportButton.vue
@@ -2,6 +2,8 @@
 import { ref, computed, watch } from "vue";
 import { useEditor } from "../composables/useEditor";
 import { useExportDialog } from "../composables/useExportDialog";
+import { useElementSelection } from "../composables/timeline/element/useElementSelection";
+import { getExportRangeFromSelectedElements } from "../lib/timeline";
 import type { ExportTranscriptSummary } from "../lib/export-summary-toast";
 import {
 	Download,
@@ -26,6 +28,7 @@ import type { Clip, ClipBuild } from "@/services/database";
 type ClipWithBuilds = Clip & { builds: ClipBuild[] };
 
 const { editor, version } = useEditor();
+const { selectedElements } = useElementSelection();
 const { isOpen, exportTimeRange, exportSegmentName, openExportDialog, closeExportDialog } = useExportDialog();
 const format = ref<"mp4" | "webm">("mp4");
 const quality = ref<"low" | "medium" | "high" | "very_high">("high");
@@ -79,6 +82,23 @@ const exportDialogSubtitle = computed(() => {
 const exportDialogTitle = computed(() =>
 	exportTimeRange.value ? "Export Segment" : "Export Configuration",
 );
+
+function handleOpenExportDialog() {
+	const selectionExport = getExportRangeFromSelectedElements({
+		elements: selectedElements.value,
+		getElement: ({ trackId, elementId }) => {
+			const track = editor.timeline.getTrackById({ trackId });
+			return track?.elements.find((el) => el.id === elementId) ?? null;
+		},
+	});
+
+	if (selectionExport) {
+		openExportDialog(selectionExport);
+		return;
+	}
+
+	openExportDialog();
+}
 
 const exportOutputFileName = computed(() => exportSegmentName.value?.trim() || null);
 
@@ -1018,7 +1038,7 @@ function handlePublishNow() {
 				hasProject ? 'cursor-pointer' : 'cursor-not-allowed opacity-50',
 			]"
 			:disabled="!hasProject"
-			@click="hasProject && openExportDialog()"
+			@click="hasProject && handleOpenExportDialog()"
 		>
 			<Download class="export-trigger__icon" />
 			Export

--- a/client/src/editor/composables/actions/useEditorActions.ts
+++ b/client/src/editor/composables/actions/useEditorActions.ts
@@ -7,8 +7,6 @@ import { useEditor } from "../useEditor";
 import { useElementSelection } from "../timeline/element/useElementSelection";
 import { SetTransitionCommand } from "../../lib/commands/scene";
 import { getElementsAtTime } from "../../lib/timeline";
-import { isMainTrack } from "../../lib/timeline/track-utils";
-import { getMainTrackMagnet } from "../timeline/useTimelineTools";
 import type { ClipboardItem, CreateTimelineElement } from "../../types/timeline";
 
 export function useEditorActions() {
@@ -157,56 +155,9 @@ export function useEditorActions() {
 
 		if (selectedElements.value.length === 0) return;
 
-		const tracks = editor.timeline.getTracks();
-		const mainTrack = tracks.find((t) => isMainTrack(t));
-		const shouldRipple = getMainTrackMagnet() && mainTrack;
-
-		// Collect info about main track elements being deleted (before deletion)
-		let deletedMainElements: Array<{ startTime: number; duration: number }> = [];
-		if (shouldRipple && mainTrack) {
-			for (const sel of selectedElements.value) {
-				if (sel.trackId === mainTrack.id) {
-					const el = mainTrack.elements.find((e) => e.id === sel.elementId);
-					if (el) {
-						deletedMainElements.push({ startTime: el.startTime, duration: el.duration });
-					}
-				}
-			}
-		}
-
 		const elementsToDelete = [...selectedElements.value];
 		clearElementSelection();
-
 		editor.timeline.deleteElements({ elements: elementsToDelete });
-
-		// Ripple: shift subsequent main track elements left to close gaps
-		if (deletedMainElements.length > 0 && mainTrack) {
-			// Sort deleted elements by startTime ascending
-			deletedMainElements.sort((a, b) => a.startTime - b.startTime);
-
-			// Calculate total gap to shift by (sum of all deleted durations)
-			// Use the earliest deleted element's start as the gap boundary
-			const gapStart = deletedMainElements[0].startTime;
-			const totalGapDuration = deletedMainElements.reduce((sum, d) => sum + d.duration, 0);
-
-			// Get current state of main track after deletion
-			const currentTracks = editor.timeline.getTracks();
-			const currentMainTrack = currentTracks.find((t) => isMainTrack(t));
-			if (currentMainTrack) {
-				// Find elements that start at or after the gap
-				const elementIdsToShift = currentMainTrack.elements
-					.filter((e) => e.startTime >= gapStart)
-					.map((e) => e.id);
-
-				if (elementIdsToShift.length > 0) {
-					editor.timeline.moveElementsBatch({
-						trackId: currentMainTrack.id,
-						elementIds: elementIdsToShift,
-						timeDelta: -totalGapDuration,
-					});
-				}
-			}
-		}
 	});
 
 	useActionHandler("select-all", () => {

--- a/client/src/editor/composables/timeline/element/useElementInteraction.ts
+++ b/client/src/editor/composables/timeline/element/useElementInteraction.ts
@@ -198,6 +198,8 @@ export function useElementInteraction({
 	let lastMouseX = 0;
 	let lastMouseY = 0;
 	let mouseDownLocation: { x: number; y: number } | null = null;
+	/** True when the current pointer gesture completed an element move drag. */
+	let didDragElementsThisGesture = false;
 	let dragSnapCache: PendingDragState | null = null;
 	let dragStartTimeValue = 0;
 	let dragStartMouseY = 0;
@@ -577,6 +579,7 @@ export function useElementInteraction({
 		// Sync linked element (e.g. extracted audio ↔ source video)
 		syncLinkedElement(ds.elementId, ds.trackId, timeDelta);
 
+		didDragElementsThisGesture = true;
 		resetDragVisual();
 	}
 
@@ -617,6 +620,17 @@ export function useElementInteraction({
 			onMouseUp(event);
 			return;
 		}
+
+		// Plain click with small pointer jitter: collapse multi-selection to the clicked clip
+		// so Delete / toolbar actions only affect the intended segment.
+		const cancelled = pendingDrag;
+		if (
+			cancelled &&
+			!(event.metaKey || event.ctrlKey || event.shiftKey || event.altKey)
+		) {
+			selectElement({ trackId: cancelled.trackId, elementId: cancelled.elementId });
+		}
+
 		pendingDrag = null;
 		isPendingDrag.value = false;
 		// No drag DOM to tear down because the drag never started.
@@ -689,6 +703,7 @@ export function useElementInteraction({
 		}
 
 		event.stopPropagation();
+		didDragElementsThisGesture = false;
 
 		const isMultiSelect = event.metaKey || event.ctrlKey || event.shiftKey || event.altKey;
 		const alreadySelected = isElementSelected({ trackId: track.id, elementId: element.id });
@@ -750,16 +765,17 @@ export function useElementInteraction({
 	}) {
 		event.stopPropagation();
 
-		if (mouseDownLocation) {
-			const deltaX = Math.abs(event.clientX - mouseDownLocation.x);
-			const deltaY = Math.abs(event.clientY - mouseDownLocation.y);
-			if (deltaX > DRAG_THRESHOLD_PX || deltaY > DRAG_THRESHOLD_PX) {
-				mouseDownLocation = null;
-				return;
-			}
+		if (event.metaKey || event.ctrlKey || event.shiftKey) return;
+
+		// Skip only when this gesture actually moved clips — not for small pointer jitter
+		// that stays below the drag threshold (that case is handled in onPendingMouseUp).
+		if (didDragElementsThisGesture) {
+			didDragElementsThisGesture = false;
+			mouseDownLocation = null;
+			return;
 		}
 
-		if (event.metaKey || event.ctrlKey || event.shiftKey) return;
+		mouseDownLocation = null;
 
 		// On plain click (no drag), collapse to single element selection.
 		// This handles: clicking an unselected element, or clicking one element

--- a/client/src/editor/core/managers/selection-manager.ts
+++ b/client/src/editor/core/managers/selection-manager.ts
@@ -15,7 +15,7 @@ export class SelectionManager {
 	}
 
 	getSelectedElements(): ElementRef[] {
-		return this.selectedElements;
+		return [...this.selectedElements];
 	}
 
 	getSelectedTransitionId(): string | null {

--- a/client/src/editor/core/managers/timeline-manager.ts
+++ b/client/src/editor/core/managers/timeline-manager.ts
@@ -8,6 +8,7 @@ import type {
 	Transform,
 } from "../../types/timeline";
 import { calculateTotalDuration } from "../../lib/timeline";
+import { getMainTrackMagnet } from "../../composables/timeline/useTimelineTools";
 import {
 	AddTrackCommand,
 	RemoveTrackCommand,
@@ -261,7 +262,7 @@ export class TimelineManager {
 	}: {
 		elements: { trackId: string; elementId: string }[];
 	}): void {
-		const command = new DeleteElementsCommand(elements);
+		const command = new DeleteElementsCommand(elements, getMainTrackMagnet());
 		this.editor.command.execute({ command });
 	}
 

--- a/client/src/editor/lib/commands/timeline/element/delete-elements.ts
+++ b/client/src/editor/lib/commands/timeline/element/delete-elements.ts
@@ -6,7 +6,11 @@ import { collapseMainVideoTracksIfPresent, isMainTrack } from "../../../../lib/t
 export class DeleteElementsCommand extends Command {
 	private savedState: TimelineTrack[] | null = null;
 
-	constructor(private elements: { trackId: string; elementId: string }[]) {
+	constructor(
+		private elements: { trackId: string; elementId: string }[],
+		/** When true (main-track magnet on), pack main video segments after deletion. */
+		private collapseMainTrackGaps = true,
+	) {
 		super();
 	}
 
@@ -36,7 +40,11 @@ export class DeleteElementsCommand extends Command {
 			.filter((track) => track.elements.length > 0 || isMainTrack(track));
 
 		const fps = editor.project.getActive()?.settings?.fps ?? 30;
-		editor.timeline.updateTracks(collapseMainVideoTracksIfPresent(updatedTracks, fps));
+		editor.timeline.updateTracks(
+			this.collapseMainTrackGaps
+				? collapseMainVideoTracksIfPresent(updatedTracks, fps)
+				: updatedTracks,
+		);
 	}
 
 	undo(): void {

--- a/client/src/editor/lib/commands/timeline/element/split-elements.ts
+++ b/client/src/editor/lib/commands/timeline/element/split-elements.ts
@@ -4,6 +4,7 @@ import type { Transition } from "../../../../types/transitions";
 import { generateUUID } from "../../../../utils/id";
 import { EditorCore } from "../../../../core";
 import { collapseMainVideoTracksIfPresent } from "../../../../lib/timeline/main-track-layout";
+import { isMainTrack } from "../../../../lib/timeline/track-utils";
 import { getElementSourceSpanSeconds } from "../../../../lib/timeline/trim-source-utils";
 
 function withoutStartFade<T extends { fadeIn?: number }>(element: T): T {
@@ -164,8 +165,37 @@ export class SplitElementsCommand extends Command {
 		}
 
 		if (this.rightSideElements.length > 0) {
-			editor.selection.setSelectedElements({ elements: this.rightSideElements });
+			const toSelect =
+				this.rightSideElements.length === 1
+					? this.rightSideElements
+					: [this.pickSingleSplitSelection({ editor, refs: this.rightSideElements })];
+			editor.selection.setSelectedElements({ elements: toSelect });
 		}
+	}
+
+	private pickSingleSplitSelection({
+		editor,
+		refs,
+	}: {
+		editor: EditorCore;
+		refs: { trackId: string; elementId: string }[];
+	}): { trackId: string; elementId: string } {
+		const tracks = editor.timeline.getTracks();
+		const ranked = refs
+			.map((ref) => {
+				const track = tracks.find((t) => t.id === ref.trackId);
+				const element = track?.elements.find((e) => e.id === ref.elementId);
+				return {
+					ref,
+					startTime: element?.startTime ?? 0,
+					isMain: track ? isMainTrack(track) : false,
+				};
+			})
+			.sort((a, b) => {
+				if (a.isMain !== b.isMain) return a.isMain ? -1 : 1;
+				return b.startTime - a.startTime;
+			});
+		return ranked[0]?.ref ?? refs[refs.length - 1];
 	}
 
 	undo(): void {

--- a/client/src/editor/lib/timeline/delete-main-track.test.ts
+++ b/client/src/editor/lib/timeline/delete-main-track.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import type { TimelineTrack } from "../../types/timeline";
+import { collapseMainVideoTrackGaps } from "./main-track-layout";
+
+function makeMainTrack(
+	elements: Array<{ id: string; startTime: number; duration: number }>,
+): TimelineTrack {
+	return {
+		id: "main",
+		type: "video",
+		isMain: true,
+		elements: elements.map((el) => ({
+			id: el.id,
+			type: "video" as const,
+			name: el.id,
+			startTime: el.startTime,
+			duration: el.duration,
+			trimStart: 0,
+			trimEnd: 0,
+			mediaId: "media-1",
+		})),
+	};
+}
+
+function deleteFromMainTrack({
+	track,
+	deleteIds,
+	collapseGaps,
+	fps = 30,
+}: {
+	track: TimelineTrack;
+	deleteIds: string[];
+	collapseGaps: boolean;
+	fps?: number;
+}): TimelineTrack {
+	const filtered = {
+		...track,
+		elements: track.elements.filter((element) => !deleteIds.includes(element.id)),
+	};
+	return collapseGaps ? collapseMainVideoTrackGaps(filtered, fps) : filtered;
+}
+
+describe("main-track delete ripple", () => {
+	it("deleting one middle segment preserves neighbors when gaps collapse once", () => {
+		const track = makeMainTrack([
+			{ id: "s1", startTime: 0, duration: 10 },
+			{ id: "s2", startTime: 10, duration: 10 },
+			{ id: "s3", startTime: 20, duration: 10 },
+			{ id: "s4", startTime: 30, duration: 10 },
+		]);
+
+		const result = deleteFromMainTrack({ track, deleteIds: ["s3"], collapseGaps: true });
+
+		expect(result.elements.map((el) => el.id)).toEqual(["s1", "s2", "s4"]);
+		expect(result.elements.map((el) => el.startTime)).toEqual([0, 10, 20]);
+	});
+
+	it("does not collapse when main-track magnet is off", () => {
+		const track = makeMainTrack([
+			{ id: "s1", startTime: 0, duration: 10 },
+			{ id: "s2", startTime: 10, duration: 10 },
+			{ id: "s3", startTime: 20, duration: 10 },
+			{ id: "s4", startTime: 30, duration: 10 },
+		]);
+
+		const result = deleteFromMainTrack({ track, deleteIds: ["s3"], collapseGaps: false });
+
+		expect(result.elements.map((el) => el.id)).toEqual(["s1", "s2", "s4"]);
+		expect(result.elements.map((el) => el.startTime)).toEqual([0, 10, 30]);
+	});
+
+	it("simulated double ripple overlaps the left neighbor before repacking", () => {
+		const track = makeMainTrack([
+			{ id: "s1", startTime: 0, duration: 10 },
+			{ id: "s2", startTime: 10, duration: 10 },
+			{ id: "s3", startTime: 20, duration: 10 },
+			{ id: "s4", startTime: 30, duration: 10 },
+		]);
+
+		const once = deleteFromMainTrack({ track, deleteIds: ["s3"], collapseGaps: true });
+		const gapStart = 20;
+		const gapDuration = 10;
+		const shifted = {
+			...once,
+			elements: once.elements.map((el) =>
+				el.startTime >= gapStart
+					? { ...el, startTime: Math.max(0, el.startTime - gapDuration) }
+					: el,
+			),
+		};
+
+		const s2 = shifted.elements.find((el) => el.id === "s2");
+		const s4 = shifted.elements.find((el) => el.id === "s4");
+		expect(s2?.startTime).toBe(10);
+		expect(s4?.startTime).toBe(10);
+		expect(s2?.startTime).toBe(s4?.startTime);
+	});
+});

--- a/client/src/editor/lib/timeline/element-utils.ts
+++ b/client/src/editor/lib/timeline/element-utils.ts
@@ -489,3 +489,27 @@ export function getElementsAtTime({
 
 	return result;
 }
+
+export function getExportRangeFromSelectedElements({
+	elements,
+	getElement,
+}: {
+	elements: { trackId: string; elementId: string }[];
+	getElement: (ref: { trackId: string; elementId: string }) => TimelineElement | null;
+}): { timeRange: { startTime: number; endTime: number }; segmentName: string } | null {
+	if (elements.length === 0) return null;
+
+	const resolved = elements
+		.map((ref) => getElement(ref))
+		.filter((el): el is TimelineElement => el !== null);
+	if (resolved.length === 0) return null;
+
+	const startTime = Math.min(...resolved.map((el) => el.startTime));
+	const endTime = Math.max(...resolved.map((el) => el.startTime + el.duration));
+	const segmentName =
+		resolved.length === 1
+			? resolved[0].name?.trim() || "Selected segment"
+			: `${resolved.length} selected segments`;
+
+	return { timeRange: { startTime, endTime }, segmentName };
+}


### PR DESCRIPTION
- Introduced a new method to calculate the export range based on selected elements in the timeline.
- Updated the ExportButton component to utilize the new export range calculation when opening the export dialog.
- Refactored element deletion logic to support main track gap management.
- Improved element selection handling during drag operations to ensure accurate user interactions.
- Bumped clippster-ui version to 0.1.240 in Cargo.toml, Cargo.lock, and tauri.conf.json.