### PR TITLE
refactor: update main track handling and version bump

### DIFF
--- a/client/src-tauri/Cargo.lock
+++ b/client/src-tauri/Cargo.lock
@@ -761,7 +761,7 @@ dependencies = [
 
 [[package]]
 name = "clippster-ui"
-version = "0.1.240"
+version = "0.1.241"
 dependencies = [
  "aes",
  "async-stream",

--- a/client/src-tauri/Cargo.toml
+++ b/client/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clippster-ui"
-version = "0.1.240"
+version = "0.1.241"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/client/src-tauri/tauri.conf.json
+++ b/client/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Clippster",
-  "version": "0.1.240",
+  "version": "0.1.241",
   "identifier": "com.openworth.clippster",
   "build": {
     "beforeDevCommand": "yarn dev",

--- a/client/src/editor/lib/timeline/delete-main-track.test.ts
+++ b/client/src/editor/lib/timeline/delete-main-track.test.ts
@@ -1,24 +1,31 @@
 import { describe, expect, it } from "vitest";
-import type { TimelineTrack } from "../../types/timeline";
+import type { VideoElement, VideoTrack } from "../../types/timeline";
 import { collapseMainVideoTrackGaps } from "./main-track-layout";
 
 function makeMainTrack(
 	elements: Array<{ id: string; startTime: number; duration: number }>,
-): TimelineTrack {
+): VideoTrack {
 	return {
 		id: "main",
 		type: "video",
+		name: "Main",
 		isMain: true,
-		elements: elements.map((el) => ({
-			id: el.id,
-			type: "video" as const,
-			name: el.id,
-			startTime: el.startTime,
-			duration: el.duration,
-			trimStart: 0,
-			trimEnd: 0,
-			mediaId: "media-1",
-		})),
+		muted: false,
+		hidden: false,
+		elements: elements.map(
+			(el): VideoElement => ({
+				id: el.id,
+				type: "video",
+				name: el.id,
+				startTime: el.startTime,
+				duration: el.duration,
+				trimStart: 0,
+				trimEnd: 0,
+				mediaId: "media-1",
+				transform: { position: { x: 0, y: 0 }, scale: 1, rotate: 0 },
+				opacity: 1,
+			}),
+		),
 	};
 }
 
@@ -28,16 +35,18 @@ function deleteFromMainTrack({
 	collapseGaps,
 	fps = 30,
 }: {
-	track: TimelineTrack;
+	track: VideoTrack;
 	deleteIds: string[];
 	collapseGaps: boolean;
 	fps?: number;
-}): TimelineTrack {
-	const filtered = {
+}): VideoTrack {
+	const filtered: VideoTrack = {
 		...track,
 		elements: track.elements.filter((element) => !deleteIds.includes(element.id)),
 	};
-	return collapseGaps ? collapseMainVideoTrackGaps(filtered, fps) : filtered;
+	return collapseGaps
+		? (collapseMainVideoTrackGaps(filtered, fps) as VideoTrack)
+		: filtered;
 }
 
 describe("main-track delete ripple", () => {


### PR DESCRIPTION
- Refactored the main track handling in delete-main-track.test.ts to use VideoTrack and VideoElement types, enhancing type safety and clarity.
- Updated the structure of the main track elements to include additional properties such as transform and opacity.
- Bumped clippster-ui version to 0.1.241 in Cargo.toml, Cargo.lock, and tauri.conf.json.