### PR TITLE
refactor: enhance renderer manager with main track handling and versi…

### DIFF
--- a/client/src-tauri/Cargo.lock
+++ b/client/src-tauri/Cargo.lock
@@ -761,7 +761,7 @@ dependencies = [
 
 [[package]]
 name = "clippster-ui"
-version = "0.1.242"
+version = "0.1.243"
 dependencies = [
  "aes",
  "async-stream",

--- a/client/src-tauri/Cargo.toml
+++ b/client/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clippster-ui"
-version = "0.1.242"
+version = "0.1.243"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/client/src-tauri/tauri.conf.json
+++ b/client/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Clippster",
-  "version": "0.1.242",
+  "version": "0.1.243",
   "identifier": "com.openworth.clippster",
   "build": {
     "beforeDevCommand": "yarn dev",

--- a/client/src/editor/core/managers/renderer-manager.ts
+++ b/client/src/editor/core/managers/renderer-manager.ts
@@ -45,6 +45,7 @@ import { resolveWatermarkById, resolveOverlayImagePath } from "@/services/databa
 import { resolveIntroOutroById } from "@/services/database/intro-outros";
 import { base64ToUtf8 } from "@/utils/encoding";
 import { resolveTransitionMediaPair } from "../../lib/timeline/transition-pairing";
+import { isMainTrack } from "../../lib/timeline/track-utils";
 import { getSceneTracksForExport, writeSceneFrameSequenceToDisk } from "../../renderer/scene-frame-export";
 
 /** True if any two [start,end) segments overlap (for FFmpeg layer compositing). */
@@ -131,6 +132,14 @@ function hasElementKeyframes(keyframes?: ElementKeyframes): boolean {
 	return Object.values(keyframes.tracks).some((track) => !!track && track.keyframes.length > 0);
 }
 
+function countMainStorySegments(track: VideoTrack): number {
+	return track.elements.filter(
+		(element) =>
+			(element.type === "video" || element.type === "image") &&
+			!("hidden" in element && element.hidden),
+	).length;
+}
+
 function requiresSceneFrameExport({
 	tracks,
 	sceneTransitions,
@@ -142,6 +151,14 @@ function requiresSceneFrameExport({
 }): boolean {
 	if (canvasSourceFraming) return true;
 	if (sceneTransitions.length > 0) return true;
+
+	// Split / multi-segment main-track edits must use the same scene renderer as preview.
+	// The fast FFmpeg concat path can export black video when several trims reference one file.
+	for (const track of tracks) {
+		if (isMainTrack(track) && countMainStorySegments(track) > 1) {
+			return true;
+		}
+	}
 
 	for (const track of tracks) {
 		if (track.type === "audio") continue;
@@ -635,8 +652,13 @@ export class RendererManager {
 				});
 				scenePattern = sceneExport.pattern;
 				sceneFrameCount = sceneExport.frameCount;
+				console.info(
+					"[RendererManager] Scene frame pre-render enabled for WYSIWYG export parity",
+				);
 			} else {
-				console.info("[RendererManager] Using fast FFmpeg export path; scene frame pre-render not required");
+				console.info(
+					"[RendererManager] Using fast FFmpeg export path; scene frame pre-render not required",
+				);
 			}
 
 			onProgress?.({ progress: 0.19 });
@@ -903,7 +925,7 @@ export class RendererManager {
 						source_path: sourcePath,
 						start_time,
 						end_time,
-						trim_start: (videoEl.trimStart ?? 0) + clip.sourceOffset || null,
+						trim_start: (videoEl.trimStart ?? 0) + clip.sourceOffset,
 						trim_end: videoEl.trimEnd ? videoEl.trimEnd - clip.sourceEndOffset : null,
 						opacity: videoEl.opacity ?? 1,
 						scale: videoEl.transform?.scale ?? 1,


### PR DESCRIPTION
…on bump

- Added a new function to count main story segments in video tracks, improving scene frame export logic.
- Updated the requiresSceneFrameExport function to ensure proper handling of multi-segment main-track edits.
- Bumped clippster-ui version to 0.1.243 in Cargo.toml, Cargo.lock, and tauri.conf.json.