### PR TITLE
feat: improve kick video duration handling and mapping

### DIFF
--- a/client/src-tauri/Cargo.lock
+++ b/client/src-tauri/Cargo.lock
@@ -761,7 +761,7 @@ dependencies = [
 
 [[package]]
 name = "clippster-ui"
-version = "0.1.246"
+version = "0.1.247"
 dependencies = [
  "aes",
  "async-stream",

--- a/client/src-tauri/Cargo.toml
+++ b/client/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clippster-ui"
-version = "0.1.246"
+version = "0.1.247"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/client/src-tauri/tauri.conf.json
+++ b/client/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Clippster",
-  "version": "0.1.246",
+  "version": "0.1.247",
   "identifier": "com.openworth.clippster",
   "build": {
     "beforeDevCommand": "yarn dev",

--- a/client/src/stores/platform.ts
+++ b/client/src/stores/platform.ts
@@ -365,9 +365,21 @@ export const usePlatformStore = defineStore('platform', {
               }
               try {
                 const d = await invoke<number>('probe_kick_vod_duration', { videoUrl: url });
-                if (typeof d === 'number' && d > 0 && !Number.isNaN(d)) {
-                  c.duration = d;
+                if (typeof d !== 'number' || d <= 0 || Number.isNaN(d)) {
+                  return;
                 }
+                const apiDuration = c.duration ?? 0;
+                // Ignore broken HLS window probes (a few seconds) when RapidAPI already
+                // reported a long VOD.
+                if (apiDuration > 120 && d < 60) {
+                  console.debug(
+                    '[Platform] Kick stream duration probe ignored (too short vs API):',
+                    c.clipId,
+                    { probed: d, apiDuration }
+                  );
+                  return;
+                }
+                c.duration = d;
               } catch (e) {
                 console.debug('[Platform] Kick stream duration probe skipped:', c.clipId, e);
               }

--- a/server/lib/clippster_server_web/controllers/kick_controller.ex
+++ b/server/lib/clippster_server_web/controllers/kick_controller.ex
@@ -133,6 +133,151 @@ defmodule ClippsterServerWeb.KickController do
     |> json(%{isLive: false, error: "Kick API request failed after retries"})
   end
 
+  # RapidAPI currently returns seconds; older Kick/native payloads used milliseconds.
+  # Values above 24h in seconds are treated as milliseconds.
+  defp normalize_kick_duration(raw) when is_integer(raw) and raw > 86_400, do: div(raw, 1000)
+  defp normalize_kick_duration(raw) when is_float(raw) and raw > 86_400, do: trunc(raw / 1000)
+  defp normalize_kick_duration(raw) when is_integer(raw) and raw >= 0, do: raw
+  defp normalize_kick_duration(raw) when is_float(raw) and raw >= 0, do: trunc(raw)
+
+  defp normalize_kick_duration(raw) when is_binary(raw) do
+    case Integer.parse(String.trim(raw)) do
+      {n, _} -> normalize_kick_duration(n)
+      :error -> 0
+    end
+  end
+
+  defp normalize_kick_duration(_), do: 0
+
+  defp kick_vod_page_url(video, channel_slug_fallback) do
+    vod_id = video["id"]
+    channel_slug =
+      get_in(video, ["channel", "slug"]) ||
+        video["channel_slug"] ||
+        video["channelSlug"] ||
+        channel_slug_fallback
+
+    if vod_id && channel_slug && to_string(vod_id) != "" && to_string(channel_slug) != "" do
+      "https://kick.com/#{channel_slug}/videos/#{vod_id}"
+    else
+      nil
+    end
+  end
+
+  # RapidAPI's videos list no longer includes HLS `source`. Kick thumbnails encode the
+  # IVS channel + recording ids, and startTime maps to the path date segments.
+  defp reconstruct_kick_hls_url(video) do
+    thumbnail =
+      get_in(video, ["thumbnail", "src"]) ||
+        get_in(video, ["thumbnail", "url"]) ||
+        video["thumbnail_url"] ||
+        video["thumbnailUrl"]
+
+    start_time =
+      video["startTime"] ||
+        video["start_time"] ||
+        video["created_at"] ||
+        video["createdAt"]
+
+    with [ivs_channel_id, recording_id] <- parse_kick_thumbnail_ids(thumbnail),
+         {:ok, date_path} <- kick_hls_date_path(start_time) do
+      "https://stream.kick.com/3c81249a5ce0/ivs/v1/196233775518/#{ivs_channel_id}/#{date_path}/#{recording_id}/media/hls/master.m3u8"
+    else
+      _ -> nil
+    end
+  end
+
+  defp parse_kick_thumbnail_ids(thumbnail) when is_binary(thumbnail) do
+    case Regex.run(~r{/video_thumbnails/([^/]+)/([^/]+)/}, thumbnail) do
+      [_, ivs_channel_id, recording_id] -> [ivs_channel_id, recording_id]
+      _ -> :error
+    end
+  end
+
+  defp parse_kick_thumbnail_ids(_), do: :error
+
+  defp kick_hls_date_path(start_time) when is_binary(start_time) do
+    normalized =
+      start_time
+      |> String.trim()
+      |> String.replace(" ", "T")
+
+    iso =
+      cond do
+        String.ends_with?(normalized, "Z") -> normalized
+        Regex.match?(~r/T\d{2}:\d{2}/, normalized) and not String.contains?(normalized, "+") ->
+          normalized <> "Z"
+
+        true ->
+          normalized
+      end
+
+    case DateTime.from_iso8601(iso) do
+      {:ok, dt, _} ->
+        {:ok, "#{dt.year}/#{dt.month}/#{dt.day}/#{dt.hour}/#{dt.minute}"}
+
+      _ ->
+        case NaiveDateTime.from_iso8601(String.trim_trailing(normalized, "Z")) do
+          {:ok, ndt} ->
+            {:ok, "#{ndt.year}/#{ndt.month}/#{ndt.day}/#{ndt.hour}/#{ndt.minute}"}
+
+          _ ->
+            :error
+        end
+    end
+  end
+
+  defp kick_hls_date_path(_), do: :error
+
+  defp map_kick_video(video, channel_slug) when is_map(video) do
+    thumbnail_url =
+      get_in(video, ["thumbnail", "src"]) ||
+        get_in(video, ["thumbnail", "url"]) ||
+        get_in(video, ["thumbnail", "responsive"]) ||
+        video["thumbnail_url"] ||
+        video["thumbnailUrl"]
+
+    created_at =
+      video["startTime"] ||
+        video["start_time"] ||
+        video["created_at"] ||
+        video["createdAt"] ||
+        get_in(video, ["video", "created_at"]) ||
+        get_in(video, ["livestream", "created_at"])
+
+    playlist_url =
+      video["source"] ||
+        video["stream"] ||
+        video["playback_url"] ||
+        video["playbackUrl"] ||
+        video["url"] ||
+        video["video_url"] ||
+        video["videoUrl"] ||
+        reconstruct_kick_hls_url(video) ||
+        kick_vod_page_url(video, channel_slug)
+
+    %{
+      clipId: to_string(video["id"] || ""),
+      sessionId: video["slug"] || to_string(video["id"] || ""),
+      title:
+        video["title"] ||
+          video["session_title"] ||
+          video["sessionTitle"] ||
+          get_in(video, ["livestream", "session_title"]),
+      duration: normalize_kick_duration(video["duration"] || 0),
+      thumbnailUrl: thumbnail_url,
+      playlistUrl: playlist_url,
+      mp4Url: nil,
+      clipType: "COMPLETE",
+      startTime: created_at,
+      createdAt: created_at,
+      isLive: video["isLive"] || video["is_live"] || false,
+      views: video["views"] || video["viewer_count"] || video["viewerCount"] || video["viewers"]
+    }
+  end
+
+  defp map_kick_video(_, _), do: nil
+
   def get_clips(conn, %{"channel_slug" => channel_slug, "limit" => limit}) do
     # RapidAPI credentials
     # Using the key provided by the user
@@ -157,13 +302,13 @@ defmodule ClippsterServerWeb.KickController do
 
     case Req.get(url, headers: headers) do
       {:ok, %Req.Response{status: 200, body: body}} ->
-        limit_int = String.to_integer(limit)
-
-        # Inspect body to see what we actually got
-        Logger.info("Kick API Response Body structure: #{inspect(body)}")
+        limit_int =
+          case Integer.parse(to_string(limit)) do
+            {n, _} when n > 0 -> n
+            _ -> 20
+          end
 
         # RapidAPI response might be wrapped in "data" or just be the array directly
-        # Based on screenshots: { "data": [...] } or just [...]
         videos_list =
           case body do
             %{"data" => data} when is_list(data) ->
@@ -180,33 +325,8 @@ defmodule ClippsterServerWeb.KickController do
         clips =
           videos_list
           |> Enum.take(limit_int)
-          |> Enum.map(fn video ->
-            # Try multiple thumbnail field paths (API response format may vary)
-            thumbnail_url =
-              get_in(video, ["thumbnail", "src"]) ||
-                get_in(video, ["thumbnail", "url"]) ||
-                get_in(video, ["thumbnail", "responsive"]) ||
-                video["thumbnail_url"] ||
-                video["thumbnailUrl"]
-
-            # Map fields safely, handle nil
-            %{
-              clipId: to_string(video["id"]),
-              sessionId: video["slug"],
-              # Handle different casing
-              title: video["session_title"] || video["sessionTitle"],
-              # ms to seconds
-              duration: (video["duration"] || 0) |> div(1000),
-              thumbnailUrl: thumbnail_url,
-              playlistUrl: video["source"],
-              mp4Url: nil,
-              clipType: "COMPLETE",
-              startTime: video["created_at"] || video["createdAt"],
-              createdAt: video["created_at"] || video["createdAt"],
-              isLive: video["is_live"] || video["isLive"],
-              views: video["viewer_count"] || video["viewerCount"] || video["views"]
-            }
-          end)
+          |> Enum.map(&map_kick_video(&1, channel_slug))
+          |> Enum.reject(&is_nil/1)
 
         json(conn, %{
           success: true,


### PR DESCRIPTION
- Enhanced the duration probing logic to ignore short durations when a longer API duration is available.
- Added normalization functions for kick video durations to handle different formats (seconds vs milliseconds).
- Refactored video mapping to streamline the extraction of relevant fields from the API response, improving robustness against varying data structures.